### PR TITLE
Ctrl+Left: Use app.ToggleMiniListForCurrentZone

### DIFF
--- a/AllTheThings.lua
+++ b/AllTheThings.lua
@@ -6181,7 +6181,7 @@ local function MinimapButtonOnClick(self, button)
 		if IsShiftKeyDown() then
 			RefreshCollections();
 		elseif IsAltKeyDown() or IsControlKeyDown() then
-			ToggleMiniListForCurrentZone();
+			app.ToggleMiniListForCurrentZone();
 		else
 			ToggleMainList();
 		end


### PR DESCRIPTION
Using the global ToggleMiniListForCurrentZone was not opening the zone
minilist when ctrl+left clicking the minimap button, but replacing the
global function with the function in the app object was resolving this
problem.