### PR TITLE
Remove unobtainable items from class trial sets

### DIFF
--- a/contrib/Parser/DATAS/12 - Item Sets/Class Trials/Level 110/06 - Monk.lua
+++ b/contrib/Parser/DATAS/12 - Item Sets/Class Trials/Level 110/06 - Monk.lua
@@ -14,38 +14,19 @@ _.GearSets =
 						}),
 						i(153859),	-- Mistdancer Sword [Windwalker x2 on Creation]
 						i(153840),	-- Mistdancer Helm
-						i(153847),	-- Mistdancer Hood
-						i(153851),	-- Mistdancer Necklace
-						i(153831),	-- Mistdancer Amulet
 						i(153842),	-- Mistdancer Pauldrons
-						i(153855),	-- Mistdancer Shoulders
 						i(153865),	-- Mistdancer Cloak of Rage
-						i(153848),	-- Mistdancer Cloak of Wisdom
-						i(153866),	-- Mistdancer Jerkin
 						i(153837),	-- Mistdancer Vest
-						i(153858),	-- Mistdancer Bindings
 						i(153844),	-- Mistdancer Cuffs
-						i(153846),	-- Mistdancer Gloves
 						i(153839),	-- Mistdancer Handguards
 						i(153843),	-- Mistdancer Cord
-						i(153857),	-- Mistdancer Waistband
-						i(153850),	-- Mistdancer Britches
 						i(153841),	-- Mistdancer Legguards
-						i(153845),	-- Mistdancer Boots
 						i(153838),	-- Mistdancer Footpads
 						i(153862),	-- Mistdancer Band of Onslaught
-						i(153832),	-- Mistdancer Band of Stoicism
-						i(153853),	-- Mistdancer Band of Wisdom
 						i(153861),	-- Mistdancer Choker
-						i(153836),	-- Mistdancer Defender Idol
-						i(153834),	-- Mistdancer Defender Stone
 						i(153863),	-- Mistdancer Ring of Onslaught
-						i(153833),	-- Mistdancer Ring of Stoicism
-						i(153852),	-- Mistdancer Ring of Wisdom
 						i(153864),	-- Mistdancer Stone of Rage
-						i(153854),	-- Mistdancer Stone of Wisdom
 						i(153860),	-- Mistdancer Idol of Rage
-						i(153849),	-- Mistdancer Idol of Wisdom
 					},
 					["classes"] = { 10 }
 				}),

--- a/contrib/Parser/DATAS/12 - Item Sets/Class Trials/Level 110/12 - Death Knight.lua
+++ b/contrib/Parser/DATAS/12 - Item Sets/Class Trials/Level 110/12 - Death Knight.lua
@@ -9,34 +9,20 @@ _.GearSets =
 				n(-142, { -- Heart-Lesion 
 					["groups"] = {
 						i(153726),	-- Heart-Lesion Blade
-						i(153747),	-- Heart-Lesion RuneBlade
-						i(153737),	-- Heart-Lesion Faceguard
+						i(153747),	-- Heart-Lesion Runeblade
 						i(153721),	-- Heart-Lesion Helm
 						i(153728),	-- Heart-Lesion Pendant
-						i(153739),	-- Heart-Lesion Amulet
 						i(153729),	-- Heart-Lesion Ring of Might
 						i(153723),	-- Heart-Lesion Pauldrons
-						i(153744),	-- Heart-Lesion Shoulderguards
 						i(153727),	-- Heart-Lesion Cloak of Battle
-						i(153734),	-- Heart-Lesion Cloak of Stoicism
 						i(153718),	-- Heart-Lesion Breastplate
-						i(153733),	-- Heart-Lesion Chestguard
-						i(153746),	-- Heart-Lesion Armguards
 						i(153725),	-- Heart-Lesion Vambraces
 						i(153720),	-- Heart-Lesion Gauntlets
-						i(153736),	-- Heart-Lesion Handguards
 						i(153724),	-- Heart-Lesion Girdle
-						i(153745),	-- Heart-Lesion Waistband
-						i(153738),	-- Heart-Lesion Legguards
 						i(153722),	-- Heart-Lesion Legplates
-						i(153735),	-- Heart-Lesion Greaves
 						i(153719),	-- Heart-Lesion Sabatons
 						i(153730),	-- Heart-Lesion Band of Might
-						i(153742),	-- Heart-Lesion Band of Stoicism
-						i(153741),	-- Heart-Lesion Ring of Stoicism
 						i(153731),	-- Heart-Lesion Stone of Battle
-						i(153740),	-- Heart-Lesion Defender Idol
-						i(153743),	-- Heart-Lesion Defender Stone
 						i(153732),	-- Heart-Lesion Idol of Battle
 					},
 					["classes"] = { 6 }


### PR DESCRIPTION
The items from these sets are not given to the player upon creating a windwalker monk and are therefore unobtainable (although it might be possible to get them through level boosting a class trial).