### PR TITLE
Update frFR.lua

### DIFF
--- a/locales/frFR.lua
+++ b/locales/frFR.lua
@@ -1,5 +1,8 @@
 -- Localization for French (France) Clients.
 if GetLocale() ~= "frFR" then return; end
 local L = AllTheThings.L;
-
 -- TODO
+L.SAVED_TO_DJ_INSTANCES["Temple noir"] = "Le Temple noir";
+L.SAVED_TO_DJ_INSTANCES["Le Puits de soleil"] = "Plateau du Puits de soleil";
+L.SAVED_TO_DJ_INSTANCES["Donjon de la Tempête"] = "L’Œil";
+L.SAVED_TO_DJ_INSTANCES["Glissecroc : caverne du sanctuaire du Serpent"] = "Caverne du sanctuaire du Serpent";


### PR DESCRIPTION
Added strings that allow proper lockout tracking in French language for the following raids:
- Serpentshrine Cavern
- The Eye
- Sunwell Plateau
- Black Temple