### PR TITLE
Quest 'Strange Engine Part' in Zangarmash is repeatable.

### DIFF
--- a/contrib/Parser/DATAS/02 - Outdoor Zones/03 Outland/Zangarmarsh/Quests.lua
+++ b/contrib/Parser/DATAS/02 - Outdoor Zones/03 Outland/Zangarmarsh/Quests.lua
@@ -580,6 +580,7 @@ _.Zones =
 							i(34469, {	-- Strange Engine Part
 								q(11531, {	-- Strange Engine Part
 									["races"] = ALLIANCE_ONLY,
+									["repeatable"] = true,
 									["requireSkill"] = 356,	-- Fishing
 								}),
 							}),


### PR DESCRIPTION
Quest 'Strange Engine Part' in Zangarmash is repeatable.