### PR TITLE
Engineering specialization recipe filter

### DIFF
--- a/contrib/Parser/DATAS/11 - Professions/Engineering/Recipes/Cataclysm Engineering - Filtered.lua
+++ b/contrib/Parser/DATAS/11 - Professions/Engineering/Recipes/Cataclysm Engineering - Filtered.lua
@@ -45,10 +45,6 @@ profession(202, {	-- Engineering
 					["categoryID"] = 737,
 					["g"] = {
 						{
-							["name"] = "Big Daddy",
-							["recipeID"] = 95707
-						},
-						{
 							["name"] = "Volatile Seaforium Blastpack",
 							["recipeID"] = 84409
 						}
@@ -111,10 +107,6 @@ profession(202, {	-- Engineering
 						{
 							["name"] = "Elementium Toolbox",
 							["recipeID"] = 84416
-						},
-						{
-							["name"] = "Gnomish Gravity Well",
-							["recipeID"] = 95705
 						},
 						{
 							["name"] = "Goblin Barbecue",

--- a/contrib/Parser/DATAS/11 - Professions/Engineering/Recipes/Engineering - Filtered.lua
+++ b/contrib/Parser/DATAS/11 - Professions/Engineering/Recipes/Engineering - Filtered.lua
@@ -33,10 +33,6 @@ profession(202, {	-- Engineering
 							["recipeID"] = 39895
 						},
 						{
-							["name"] = "Goblin Rocket Fuel Recipe",
-							["recipeID"] = 12715
-						},
-						{
 							["name"] = "Gold Power Core",
 							["recipeID"] = 12584
 						},
@@ -51,10 +47,6 @@ profession(202, {	-- Engineering
 						{
 							["name"] = "Heavy Blasting Powder",
 							["recipeID"] = 3945
-						},
-						{
-							["name"] = "Inlaid Mithril Cylinder Plans",
-							["recipeID"] = 12895
 						},
 						{
 							["name"] = "Iron Strut",
@@ -151,24 +143,8 @@ profession(202, {	-- Engineering
 							["recipeID"] = 8243
 						},
 						{
-							["name"] = "Goblin Bomb Dispenser",
-							["recipeID"] = 12755
-						},
-						{
-							["name"] = "Goblin Dragon Gun",
-							["recipeID"] = 12908
-						},
-						{
 							["name"] = "Goblin Land Mine",
 							["recipeID"] = 3968
-						},
-						{
-							["name"] = "Goblin Mortar",
-							["recipeID"] = 12716
-						},
-						{
-							["name"] = "Goblin Sapper Charge",
-							["recipeID"] = 12760
 						},
 						{
 							["name"] = "Heavy Dynamite",
@@ -223,10 +199,6 @@ profession(202, {	-- Engineering
 							["recipeID"] = 12586
 						},
 						{
-							["name"] = "The Big One",
-							["recipeID"] = 12754
-						},
-						{
 							["name"] = "The Mortar: Reloaded",
 							["recipeID"] = 13240,
 							["u"] = 2
@@ -270,10 +242,6 @@ profession(202, {	-- Engineering
 						{
 							["name"] = "Flying Tiger Goggles",
 							["recipeID"] = 3934
-						},
-						{
-							["name"] = "Gnomish Goggles",
-							["recipeID"] = 12897
 						},
 						{
 							["name"] = "Green Lens",
@@ -334,10 +302,6 @@ profession(202, {	-- Engineering
 							["recipeID"] = 12617
 						},
 						{
-							["name"] = "Dimensional Ripper - Everlook",
-							["recipeID"] = 23486
-						},
-						{
 							["name"] = "Discombobulator Ray",
 							["recipeID"] = 3959
 						},
@@ -354,68 +318,16 @@ profession(202, {	-- Engineering
 							["recipeID"] = 22797
 						},
 						{
-							["name"] = "Gnomish Alarm-o-Bot",
-							["recipeID"] = 23096
-						},
-						{
-							["name"] = "Gnomish Battle Chicken",
-							["recipeID"] = 12906
-						},
-						{
 							["name"] = "Gnomish Cloaking Device",
 							["recipeID"] = 3971
-						},
-						{
-							["name"] = "Gnomish Death Ray",
-							["recipeID"] = 12759
-						},
-						{
-							["name"] = "Gnomish Harm Prevention Belt",
-							["recipeID"] = 12903
-						},
-						{
-							["name"] = "Gnomish Mind Control Cap",
-							["recipeID"] = 12907
-						},
-						{
-							["name"] = "Gnomish Net-o-Matic Projector",
-							["recipeID"] = 12902
-						},
-						{
-							["name"] = "Gnomish Rocket Boots",
-							["recipeID"] = 12905
-						},
-						{
-							["name"] = "Gnomish Shrink Ray",
-							["recipeID"] = 12899
 						},
 						{
 							["name"] = "Gnomish Universal Remote",
 							["recipeID"] = 9269
 						},
 						{
-							["name"] = "Goblin Construction Helmet",
-							["recipeID"] = 12718
-						},
-						{
 							["name"] = "Goblin Jumper Cables",
 							["recipeID"] = 9273
-						},
-						{
-							["name"] = "Goblin Jumper Cables XL",
-							["recipeID"] = 23078
-						},
-						{
-							["name"] = "Goblin Mining Helmet",
-							["recipeID"] = 12717
-						},
-						{
-							["name"] = "Goblin Rocket Boots",
-							["recipeID"] = 8895
-						},
-						{
-							["name"] = "Goblin Rocket Helmet",
-							["recipeID"] = 12758
 						},
 						{
 							["name"] = "Gyrofreeze Ice Reflector",
@@ -438,10 +350,6 @@ profession(202, {	-- Engineering
 						{
 							["name"] = "Lifelike Mechanical Toad",
 							["recipeID"] = 19793
-						},
-						{
-							["name"] = "Lil' Smoky",
-							["recipeID"] = 15633
 						},
 						{
 							["name"] = "Major Recombobulator",
@@ -506,17 +414,8 @@ profession(202, {	-- Engineering
 							["recipeID"] = 23082
 						},
 						{
-							["name"] = "Ultrasafe Transporter - Gadgetzan",
-							["recipeID"] = 23489,
-							["description"] = "Speak to Jhordy Lapforge in Gadgetzan at 52.17, 27.88 to learn this recipe.",
-						},
-						{
 							["name"] = "Voice Amplification Modulator",
 							["recipeID"] = 19819
-						},
-						{
-							["name"] = "World Enlarger",
-							["recipeID"] = 23129
 						}
 					}
 				},

--- a/contrib/Parser/DATAS/11 - Professions/Engineering/Recipes/Gnomish/Gnomish Engineering.lua
+++ b/contrib/Parser/DATAS/11 - Professions/Engineering/Recipes/Gnomish/Gnomish Engineering.lua
@@ -1,0 +1,173 @@
+profession(20219, {	-- Gnomish Engineering
+	filter(200, {
+		{
+			["name"] = "Pandaria Engineering",
+			["categoryID"] = 713,
+			["g"] = {
+				{
+					["name"] = "Mounts",
+					["categoryID"] = 733,
+					["g"] = {
+						{
+							["name"] = "Geosynchronous World Spinner",
+							["recipeID"] = 127139
+						}
+					}
+				}
+			}
+		},
+		{
+			["name"] = "Cataclysm Engineering",
+			["categoryID"] = 715,
+			["g"] = {
+				{
+					["name"] = "Devices",
+					["categoryID"] = 739,
+					["g"] = {
+						{
+							["name"] = "Gnomish Gravity Well",
+							["recipeID"] = 95705
+						}
+					}
+				}
+			}
+		},
+		{
+			["name"] = "Northrend Engineering",
+			["categoryID"] = 717,
+			["g"] = {
+				{
+					["name"] = "Goggles",
+					["categoryID"] = 745,
+					["g"] = {
+						{
+							["name"] = "Gnomish X-Ray Specs",
+							["recipeID"] = 56473
+						}
+					}
+				}
+			}
+		},
+		{
+			["name"] = "Outland Engineering",
+			["categoryID"] = 719,
+			["g"] = {
+				{
+					["name"] = "Goggles",
+					["categoryID"] = 752,
+					["g"] = {
+						{
+							["name"] = "Gnomish Battle Goggles",
+							["recipeID"] = 30575
+						},
+						{
+							["name"] = "Gnomish Power Goggles",
+							["recipeID"] = 30574
+						}
+					}
+				},
+				{
+					["name"] = "Devices",
+					["categoryID"] = 753,
+					["g"] = {
+						{
+							["name"] = "Gnomish Flame Turret",
+							["recipeID"] = 30568
+						},
+						{
+							["name"] = "Gnomish Poultryizer",
+							["recipeID"] = 30569
+						},
+						{
+							["name"] = "Nigh-Invulnerability Belt",
+							["recipeID"] = 30570
+						},
+						{
+							["name"] = "Ultrasafe Transporter - Toshley's Station",
+							["recipeID"] = 36955,
+							["description"] = "Speak to Smiles O'Byron just outside Toshley's Station in Blade's Edge Mountains at 60.35, 65.21 to learn this recipe.",
+						}
+					}
+				}
+			}
+		},
+		{
+			["name"] = "Engineering",
+			["categoryID"] = 419,
+			["g"] = {
+				{
+					["name"] = "Parts",
+					["categoryID"] = 183,
+					["g"] = {
+						{
+							["name"] = "Inlaid Mithril Cylinder Plans",
+							["recipeID"] = 12895
+						}
+					}
+				},
+				{
+					["name"] = "Goggles",
+					["categoryID"] = 185,
+					["g"] = {
+						{
+							["name"] = "Gnomish Goggles",
+							["recipeID"] = 12897
+						}
+					}
+				},
+				{
+					["name"] = "Devices",
+					["categoryID"] = 188,
+					["g"] = {
+						{
+							["name"] = "Gnomish Alarm-o-Bot",
+							["recipeID"] = 23096
+						},
+						{
+							["name"] = "Gnomish Battle Chicken",
+							["recipeID"] = 12906
+						},	
+						{
+							["name"] = "Gnomish Death Ray",
+							["recipeID"] = 12759
+						},
+						{
+							["name"] = "Gnomish Harm Prevention Belt",
+							["recipeID"] = 12903
+						},
+						
+						{
+							["name"] = "Gnomish Mind Control Cap",
+							["recipeID"] = 12907
+						},
+						{
+							["name"] = "Gnomish Net-o-Matic Projector",
+							["recipeID"] = 12902
+						},
+						{
+							["name"] = "Gnomish Rocket Boots",
+							["recipeID"] = 12905
+						},
+						{
+							["name"] = "Gnomish Shrink Ray",
+							["recipeID"] = 12899
+						},
+						{
+							["name"] = "Lil' Smoky",
+							["recipeID"] = 15633
+						},
+						{
+							["name"] = "Ultrasafe Transporter - Gadgetzan",
+							["recipeID"] = 23489,
+							["description"] = "Speak to Jhordy Lapforge in Gadgetzan at 52.17, 27.88 to learn this recipe.",
+						},
+						{
+							["name"] = "World Enlarger",
+							["recipeID"] = 23129
+						}
+					}
+				}
+			}
+		},
+	}),
+});

--- a/contrib/Parser/DATAS/11 - Professions/Engineering/Recipes/Goblin/Goblin Engineering.lua
+++ b/contrib/Parser/DATAS/11 - Professions/Engineering/Recipes/Goblin/Goblin Engineering.lua
@@ -1,0 +1,168 @@
+profession(20222, {	-- Goblin Engineering
+	filter(200, {
+		{
+			["name"] = "Pandaria Engineering",
+			["categoryID"] = 713,
+			["g"] = {
+				{
+					["name"] = "Mounts",
+					["categoryID"] = 733,
+					["g"] = {
+						{
+							["name"] = "Depleted-Kyparium Rocket",
+							["recipeID"] = 127138
+						}
+					}
+				}
+			}
+		},
+		{
+			["name"] = "Cataclysm Engineering",
+			["categoryID"] = 715,
+			["g"] = {
+				{
+					["name"] = "Explosives",
+					["categoryID"] = 737,
+					["g"] = {
+						{
+							["name"] = "Big Daddy",
+							["recipeID"] = 95707
+						}
+					}
+				}
+			}
+		},
+		{
+			["name"] = "Northrend Engineering",
+			["categoryID"] = 717,
+			["g"] = {
+				{
+					["name"] = "Explosives",
+					["categoryID"] = 744,
+					["g"] = {
+						{
+							["name"] = "Global Thermal Sapper Charge",
+							["recipeID"] = 56514
+						}
+					}
+				}
+			}
+		},
+		{
+			["name"] = "Outland Engineering",
+			["categoryID"] = 719,
+			["g"] = {
+				{
+					["name"] = "Explosives",
+					["categoryID"] = 751,
+					["g"] = {
+						{
+							["name"] = "Super Sapper Charge",
+							["recipeID"] = 30560
+						},
+						{
+							["name"] = "The Bigger One",
+							["recipeID"] = 30558
+						}
+					}
+				},
+				{
+					["name"] = "Devices",
+					["categoryID"] = 753,
+					["g"] = {
+						{
+							["name"] = "Dimensional Ripper - Area 52",
+							["recipeID"] = 36954,
+							["description"] = "Speak to Kablamm Farflinger in Netherstorm at 38.8, 63.6 to learn this recipe.",
+						},
+						{
+							["name"] = "Foreman's Enchanted Helmet",
+							["recipeID"] = 30565
+						},
+						{
+							["name"] = "Foreman's Reinforced Helmet",
+							["recipeID"] = 30566
+						},
+						{
+							["name"] = "Goblin Rocket Launcher",
+							["recipeID"] = 30563
+						}
+					}
+				}
+			}
+		},
+		{
+			["name"] = "Engineering",
+			["categoryID"] = 419,
+			["g"] = {
+				{
+					["name"] = "Parts",
+					["categoryID"] = 183,
+					["g"] = {
+						{
+							["name"] = "Goblin Rocket Fuel Recipe",
+							["recipeID"] = 12715
+						}
+					}
+				},
+				{
+					["name"] = "Explosives",
+					["categoryID"] = 184,
+					["g"] = {
+						{
+							["name"] = "Goblin Bomb Dispenser",
+							["recipeID"] = 12755
+						},
+						{
+							["name"] = "Goblin Dragon Gun",
+							["recipeID"] = 12908
+						},
+						{
+							["name"] = "Goblin Mortar",
+							["recipeID"] = 12716
+						},
+						{
+							["name"] = "Goblin Sapper Charge",
+							["recipeID"] = 12760
+						},
+						{
+							["name"] = "The Big One",
+							["recipeID"] = 12754
+						}
+					}
+				},
+				{
+					["name"] = "Devices",
+					["categoryID"] = 188,
+					["g"] = {
+						{
+							["name"] = "Dimensional Ripper - Everlook",
+							["recipeID"] = 23486,
+							["description"] = "Speak to Zap Farflinger in  Winterspring at 59.6, 49.8 to learn this recipe.",
+						},
+						{
+							["name"] = "Goblin Construction Helmet",
+							["recipeID"] = 12718
+						},
+						{
+							["name"] = "Goblin Jumper Cables XL",
+							["recipeID"] = 23078
+						},
+						{
+							["name"] = "Goblin Mining Helmet",
+							["recipeID"] = 12717
+						},
+						{
+							["name"] = "Goblin Rocket Boots",
+							["recipeID"] = 8895
+						},
+						{
+							["name"] = "Goblin Rocket Helmet",
+							["recipeID"] = 12758
+						}
+					}
+				}
+			}
+		},
+	}),
+});

--- a/contrib/Parser/DATAS/11 - Professions/Engineering/Recipes/Northrend Engineering - Filtered.lua
+++ b/contrib/Parser/DATAS/11 - Professions/Engineering/Recipes/Northrend Engineering - Filtered.lua
@@ -68,10 +68,6 @@ profession(202, {	-- Engineering
 							["name"] = "Explosive Decoy",
 							["recipeID"] = 56463
 						},
-						{
-							["name"] = "Global Thermal Sapper Charge",
-							["recipeID"] = 56514
-						}
 					}
 				},
 				{
@@ -89,10 +85,6 @@ profession(202, {	-- Engineering
 						{
 							["name"] = "Electroflux Sight Enhancers",
 							["recipeID"] = 56487
-						},
-						{
-							["name"] = "Gnomish X-Ray Specs",
-							["recipeID"] = 56473
 						},
 						{
 							["name"] = "Greensight Gogs",

--- a/contrib/Parser/DATAS/11 - Professions/Engineering/Recipes/Outland Engineering - Filtered.lua
+++ b/contrib/Parser/DATAS/11 - Professions/Engineering/Recipes/Outland Engineering - Filtered.lua
@@ -61,14 +61,6 @@ profession(202, {	-- Engineering
 						{
 							["name"] = "Frost Grenade",
 							["recipeID"] = 39973
-						},
-						{
-							["name"] = "Super Sapper Charge",
-							["recipeID"] = 30560
-						},
-						{
-							["name"] = "The Bigger One",
-							["recipeID"] = 30558
 						}
 					}
 				},
@@ -78,7 +70,8 @@ profession(202, {	-- Engineering
 					["g"] = {
 						{
 							["name"] = "Annihilator Holo-Gogs",
-							["recipeID"] = 46111
+							["recipeID"] = 46111,
+							["classes"] = { 5,8,9 } -- Priest, Mage, Warlock
 						},
 						{
 							["name"] = "Cogspinner Goggles",
@@ -101,20 +94,14 @@ profession(202, {	-- Engineering
 							["recipeID"] = 41315
 						},
 						{
-							["name"] = "Gnomish Battle Goggles",
-							["recipeID"] = 30575
-						},
-						{
-							["name"] = "Gnomish Power Goggles",
-							["recipeID"] = 30574
-						},
-						{
 							["name"] = "Hard Khorium Goggles",
-							["recipeID"] = 46115
+							["recipeID"] = 46115,
+							["classes"] = { 1,2,6 } -- Warrior, Paladin, Death Knight
 						},
 						{
 							["name"] = "Hyper-Magnified Moon Specs",
-							["recipeID"] = 46109
+							["recipeID"] = 46109,
+							["classes"] = { 11 } -- Druid
 						},
 						{
 							["name"] = "Hyper-Vision Goggles",
@@ -126,11 +113,13 @@ profession(202, {	-- Engineering
 						},
 						{
 							["name"] = "Justicebringer 3000 Specs",
-							["recipeID"] = 46107
+							["recipeID"] = 46107,
+							["classes"] = { 2 } -- Paladin
 						},
 						{
 							["name"] = "Lightning Etched Specs",
-							["recipeID"] = 46112
+							["recipeID"] = 46112,
+							["classes"] = { 7 } -- Shaman
 						},
 						{
 							["name"] = "Living Replicator Specs",
@@ -142,7 +131,8 @@ profession(202, {	-- Engineering
 						},
 						{
 							["name"] = "Mayhem Projection Goggles",
-							["recipeID"] = 46114
+							["recipeID"] = 46114,
+							["classes"] = { 11 } -- Druid
 						},
 						{
 							["name"] = "Power Amplification Goggles",
@@ -154,15 +144,18 @@ profession(202, {	-- Engineering
 						},
 						{
 							["name"] = "Powerheal 9000 Lens",
-							["recipeID"] = 46108
+							["recipeID"] = 46108,
+							["classes"] = { 5 } -- Priest
 						},
 						{
 							["name"] = "Primal-Attuned Goggles",
-							["recipeID"] = 46110
+							["recipeID"] = 46110,
+							["classes"] = { 7 } -- Shaman
 						},
 						{
 							["name"] = "Quad Deathblow X44 Goggles",
-							["recipeID"] = 46116
+							["recipeID"] = 46116,
+							["classes"] = { 4,10,11 } -- Rogue, Monk, Druid
 						},
 						{
 							["name"] = "Surestrike Goggles v2.0",
@@ -170,7 +163,8 @@ profession(202, {	-- Engineering
 						},
 						{
 							["name"] = "Surestrike Goggles v3.0",
-							["recipeID"] = 46113
+							["recipeID"] = 46113,
+							["classes"] = { 3,7 } -- Hunter, Shaman
 						},
 						{
 							["name"] = "Tankatronic Goggles",
@@ -186,7 +180,8 @@ profession(202, {	-- Engineering
 						},
 						{
 							["name"] = "Wonderheal XT68 Shades",
-							["recipeID"] = 46106
+							["recipeID"] = 46106,
+							["classes"] = { 11 } -- Druid
 						}
 					}
 				},
@@ -199,36 +194,12 @@ profession(202, {	-- Engineering
 							["recipeID"] = 30337
 						},
 						{
-							["name"] = "Dimensional Ripper - Area 52",
-							["recipeID"] = 36954
-						},
-						{
 							["name"] = "Fel Iron Toolbox",
 							["recipeID"] = 30348
 						},
 						{
 							["name"] = "Field Repair Bot 110G",
 							["recipeID"] = 44391
-						},
-						{
-							["name"] = "Foreman's Enchanted Helmet",
-							["recipeID"] = 30565
-						},
-						{
-							["name"] = "Foreman's Reinforced Helmet",
-							["recipeID"] = 30566
-						},
-						{
-							["name"] = "Gnomish Flame Turret",
-							["recipeID"] = 30568
-						},
-						{
-							["name"] = "Gnomish Poultryizer",
-							["recipeID"] = 30569
-						},
-						{
-							["name"] = "Goblin Rocket Launcher",
-							["recipeID"] = 30563
 						},
 						{
 							["name"] = "Healing Potion Injector",
@@ -239,21 +210,12 @@ profession(202, {	-- Engineering
 							["recipeID"] = 30552
 						},
 						{
-							["name"] = "Nigh-Invulnerability Belt",
-							["recipeID"] = 30570
-						},
-						{
 							["name"] = "Rocket Boots Xtreme",
 							["recipeID"] = 30556
 						},
 						{
 							["name"] = "Rocket Boots Xtreme Lite",
 							["recipeID"] = 46697
-						},
-						{
-							["name"] = "Ultrasafe Transporter - Toshley's Station",
-							["recipeID"] = 36955,
-							["description"] = "Requires Gnomish Engineering. Speak to Smiles O'Byron just outside Toshley's Station in Blade's Edge Mountains at 60.35, 65.21 to learn this recipe.",
 						},
 						{
 							["name"] = "Zapthrottle Mote Extractor",

--- a/contrib/Parser/DATAS/11 - Professions/Engineering/Recipes/Pandaria Engineering - Filtered.lua
+++ b/contrib/Parser/DATAS/11 - Professions/Engineering/Recipes/Pandaria Engineering - Filtered.lua
@@ -191,14 +191,6 @@ profession(202, {	-- Engineering
 					["categoryID"] = 733,
 					["g"] = {
 						{
-							["name"] = "Depleted-Kyparium Rocket",
-							["recipeID"] = 127138
-						},
-						{
-							["name"] = "Geosynchronous World Spinner",
-							["recipeID"] = 127139
-						},
-						{
 							["name"] = "Sky Golem",
 							["recipeID"] = 139192
 						}

--- a/contrib/Parser/DATAS/11 - Professions/Engineering/Recipes/_ Automation.lua
+++ b/contrib/Parser/DATAS/11 - Professions/Engineering/Recipes/_ Automation.lua
@@ -1432,14 +1432,6 @@ profession(202, {	-- Engineering
 					["categoryID"] = 733,
 					["g"] = {
 						{
-							["name"] = "Depleted-Kyparium Rocket",
-							["recipeID"] = 127138
-						},
-						{
-							["name"] = "Geosynchronous World Spinner",
-							["recipeID"] = 127139
-						},
-						{
 							["name"] = "Sky Golem",
 							["recipeID"] = 139192
 						}
@@ -1530,10 +1522,6 @@ profession(202, {	-- Engineering
 					["categoryID"] = 737,
 					["g"] = {
 						{
-							["name"] = "Big Daddy",
-							["recipeID"] = 95707
-						},
-						{
 							["name"] = "Volatile Seaforium Blastpack",
 							["recipeID"] = 84409
 						}
@@ -1596,10 +1584,6 @@ profession(202, {	-- Engineering
 						{
 							["name"] = "Elementium Toolbox",
 							["recipeID"] = 84416
-						},
-						{
-							["name"] = "Gnomish Gravity Well",
-							["recipeID"] = 95705
 						},
 						{
 							["name"] = "Goblin Barbecue",
@@ -1744,10 +1728,6 @@ profession(202, {	-- Engineering
 						{
 							["name"] = "Explosive Decoy",
 							["recipeID"] = 56463
-						},
-						{
-							["name"] = "Global Thermal Sapper Charge",
-							["recipeID"] = 56514
 						}
 					}
 				},
@@ -1766,10 +1746,6 @@ profession(202, {	-- Engineering
 						{
 							["name"] = "Electroflux Sight Enhancers",
 							["recipeID"] = 56487
-						},
-						{
-							["name"] = "Gnomish X-Ray Specs",
-							["recipeID"] = 56473
 						},
 						{
 							["name"] = "Greensight Gogs",
@@ -1984,14 +1960,6 @@ profession(202, {	-- Engineering
 						{
 							["name"] = "Frost Grenade",
 							["recipeID"] = 39973
-						},
-						{
-							["name"] = "Super Sapper Charge",
-							["recipeID"] = 30560
-						},
-						{
-							["name"] = "The Bigger One",
-							["recipeID"] = 30558
 						}
 					}
 				},
@@ -2022,14 +1990,6 @@ profession(202, {	-- Engineering
 						{
 							["name"] = "Gadgetstorm Goggles",
 							["recipeID"] = 41315
-						},
-						{
-							["name"] = "Gnomish Battle Goggles",
-							["recipeID"] = 30575
-						},
-						{
-							["name"] = "Gnomish Power Goggles",
-							["recipeID"] = 30574
 						},
 						{
 							["name"] = "Hard Khorium Goggles",
@@ -2122,36 +2082,12 @@ profession(202, {	-- Engineering
 							["recipeID"] = 30337
 						},
 						{
-							["name"] = "Dimensional Ripper - Area 52",
-							["recipeID"] = 36954
-						},
-						{
 							["name"] = "Fel Iron Toolbox",
 							["recipeID"] = 30348
 						},
 						{
 							["name"] = "Field Repair Bot 110G",
 							["recipeID"] = 44391
-						},
-						{
-							["name"] = "Foreman's Enchanted Helmet",
-							["recipeID"] = 30565
-						},
-						{
-							["name"] = "Foreman's Reinforced Helmet",
-							["recipeID"] = 30566
-						},
-						{
-							["name"] = "Gnomish Flame Turret",
-							["recipeID"] = 30568
-						},
-						{
-							["name"] = "Gnomish Poultryizer",
-							["recipeID"] = 30569
-						},
-						{
-							["name"] = "Goblin Rocket Launcher",
-							["recipeID"] = 30563
 						},
 						{
 							["name"] = "Healing Potion Injector",
@@ -2162,20 +2098,12 @@ profession(202, {	-- Engineering
 							["recipeID"] = 30552
 						},
 						{
-							["name"] = "Nigh-Invulnerability Belt",
-							["recipeID"] = 30570
-						},
-						{
 							["name"] = "Rocket Boots Xtreme",
 							["recipeID"] = 30556
 						},
 						{
 							["name"] = "Rocket Boots Xtreme Lite",
 							["recipeID"] = 46697
-						},
-						{
-							["name"] = "Ultrasafe Transporter - Toshley's Station",
-							["recipeID"] = 36955
 						},
 						{
 							["name"] = "Zapthrottle Mote Extractor",
@@ -2298,10 +2226,6 @@ profession(202, {	-- Engineering
 							["recipeID"] = 39895
 						},
 						{
-							["name"] = "Goblin Rocket Fuel Recipe",
-							["recipeID"] = 12715
-						},
-						{
 							["name"] = "Gold Power Core",
 							["recipeID"] = 12584
 						},
@@ -2316,10 +2240,6 @@ profession(202, {	-- Engineering
 						{
 							["name"] = "Heavy Blasting Powder",
 							["recipeID"] = 3945
-						},
-						{
-							["name"] = "Inlaid Mithril Cylinder Plans",
-							["recipeID"] = 12895
 						},
 						{
 							["name"] = "Iron Strut",
@@ -2416,24 +2336,8 @@ profession(202, {	-- Engineering
 							["recipeID"] = 8243
 						},
 						{
-							["name"] = "Goblin Bomb Dispenser",
-							["recipeID"] = 12755
-						},
-						{
-							["name"] = "Goblin Dragon Gun",
-							["recipeID"] = 12908
-						},
-						{
 							["name"] = "Goblin Land Mine",
 							["recipeID"] = 3968
-						},
-						{
-							["name"] = "Goblin Mortar",
-							["recipeID"] = 12716
-						},
-						{
-							["name"] = "Goblin Sapper Charge",
-							["recipeID"] = 12760
 						},
 						{
 							["name"] = "Heavy Dynamite",
@@ -2488,10 +2392,6 @@ profession(202, {	-- Engineering
 							["recipeID"] = 12586
 						},
 						{
-							["name"] = "The Big One",
-							["recipeID"] = 12754
-						},
-						{
 							["name"] = "The Mortar: Reloaded",
 							["recipeID"] = 13240
 						},
@@ -2532,10 +2432,6 @@ profession(202, {	-- Engineering
 						{
 							["name"] = "Flying Tiger Goggles",
 							["recipeID"] = 3934
-						},
-						{
-							["name"] = "Gnomish Goggles",
-							["recipeID"] = 12897
 						},
 						{
 							["name"] = "Green Lens",
@@ -2596,10 +2492,6 @@ profession(202, {	-- Engineering
 							["recipeID"] = 12617
 						},
 						{
-							["name"] = "Dimensional Ripper - Everlook",
-							["recipeID"] = 23486
-						},
-						{
 							["name"] = "Discombobulator Ray",
 							["recipeID"] = 3959
 						},
@@ -2616,68 +2508,16 @@ profession(202, {	-- Engineering
 							["recipeID"] = 22797
 						},
 						{
-							["name"] = "Gnomish Alarm-o-Bot",
-							["recipeID"] = 23096
-						},
-						{
-							["name"] = "Gnomish Battle Chicken",
-							["recipeID"] = 12906
-						},
-						{
 							["name"] = "Gnomish Cloaking Device",
 							["recipeID"] = 3971
-						},
-						{
-							["name"] = "Gnomish Death Ray",
-							["recipeID"] = 12759
-						},
-						{
-							["name"] = "Gnomish Harm Prevention Belt",
-							["recipeID"] = 12903
-						},
-						{
-							["name"] = "Gnomish Mind Control Cap",
-							["recipeID"] = 12907
-						},
-						{
-							["name"] = "Gnomish Net-o-Matic Projector",
-							["recipeID"] = 12902
-						},
-						{
-							["name"] = "Gnomish Rocket Boots",
-							["recipeID"] = 12905
-						},
-						{
-							["name"] = "Gnomish Shrink Ray",
-							["recipeID"] = 12899
 						},
 						{
 							["name"] = "Gnomish Universal Remote",
 							["recipeID"] = 9269
 						},
 						{
-							["name"] = "Goblin Construction Helmet",
-							["recipeID"] = 12718
-						},
-						{
 							["name"] = "Goblin Jumper Cables",
 							["recipeID"] = 9273
-						},
-						{
-							["name"] = "Goblin Jumper Cables XL",
-							["recipeID"] = 23078
-						},
-						{
-							["name"] = "Goblin Mining Helmet",
-							["recipeID"] = 12717
-						},
-						{
-							["name"] = "Goblin Rocket Boots",
-							["recipeID"] = 8895
-						},
-						{
-							["name"] = "Goblin Rocket Helmet",
-							["recipeID"] = 12758
 						},
 						{
 							["name"] = "Gyrofreeze Ice Reflector",
@@ -2698,10 +2538,6 @@ profession(202, {	-- Engineering
 						{
 							["name"] = "Lifelike Mechanical Toad",
 							["recipeID"] = 19793
-						},
-						{
-							["name"] = "Lil' Smoky",
-							["recipeID"] = 15633
 						},
 						{
 							["name"] = "Major Recombobulator",
@@ -2764,16 +2600,8 @@ profession(202, {	-- Engineering
 							["recipeID"] = 23082
 						},
 						{
-							["name"] = "Ultrasafe Transporter - Gadgetzan",
-							["recipeID"] = 23489
-						},
-						{
 							["name"] = "Voice Amplification Modulator",
 							["recipeID"] = 19819
-						},
-						{
-							["name"] = "World Enlarger",
-							["recipeID"] = 23129
 						}
 					}
 				},


### PR DESCRIPTION
I added filtering in profession recipes based on specialization, for BFA the only profession that still has exclusive recipes is engineering but it could be extended for Classic for Blacksmithing, Leatherworking, and Tailoring because I have not hardcoded the specializations, there is a table between professions and specializations.

For players who want to filter recipes without the account wide option enable currently the addon does not show recipes for not learned profession, from other classes or from other factions, so it makes sense that specializations work the same way and exclude recipes from the non-learned specialization.

What happens if the players have not learned any specialization? Exactly the same as what happens if the player has not learned any profession, the recipes do not appear in the addon list until the player learns the profession, specializations works like professions.

What happens if the players forgot a specialization? Exactly the same as what happens if the player forgot a profession, recipes from forgotten specializations disappear just like recipes from forgotten professions disappear. 

With this change, specializations are shown in profession list as another profession, I tried to put specializations bellow the engineering category but it was not able to make it work.

Also, I added class restrictions for sunwell engineering goggles, players are not able to learn those recipes if they are not the appropriate class.