### PR TITLE
Moved cataclysm gnome and goblin engineering pets to specialization recipes

### DIFF
--- a/contrib/Parser/DATAS/11 - Professions/Engineering/Recipes/Cataclysm Engineering - Filtered.lua
+++ b/contrib/Parser/DATAS/11 - Professions/Engineering/Recipes/Cataclysm Engineering - Filtered.lua
@@ -93,10 +93,6 @@ profession(202, {	-- Engineering
 					["categoryID"] = 739,
 					["g"] = {
 						{
-							["name"] = "De-Weaponized Mechanical Companion",
-							["recipeID"] = 84413
-						},
-						{
 							["name"] = "Electrostatic Condenser",
 							["recipeID"] = 95703
 						},
@@ -123,10 +119,6 @@ profession(202, {	-- Engineering
 						{
 							["name"] = "Lure Master Tackle Box",
 							["recipeID"] = 84415
-						},
-						{
-							["name"] = "Personal World Destroyer",
-							["recipeID"] = 84412
 						}
 					}
 				},

--- a/contrib/Parser/DATAS/11 - Professions/Engineering/Recipes/Gnomish/Gnomish Engineering.lua
+++ b/contrib/Parser/DATAS/11 - Professions/Engineering/Recipes/Gnomish/Gnomish Engineering.lua
@@ -25,6 +25,10 @@ profession(20219, {	-- Gnomish Engineering
 					["categoryID"] = 739,
 					["g"] = {
 						{
+							["name"] = "De-Weaponized Mechanical Companion",
+							["recipeID"] = 84413
+						},
+						{
 							["name"] = "Gnomish Gravity Well",
 							["recipeID"] = 95705
 						}

--- a/contrib/Parser/DATAS/11 - Professions/Engineering/Recipes/Goblin/Goblin Engineering.lua
+++ b/contrib/Parser/DATAS/11 - Professions/Engineering/Recipes/Goblin/Goblin Engineering.lua
@@ -29,6 +29,16 @@ profession(20222, {	-- Goblin Engineering
 							["recipeID"] = 95707
 						}
 					}
+				},
+				{
+					["name"] = "Devices",
+					["categoryID"] = 739,
+					["g"] = {
+						{
+							["name"] = "Personal World Destroyer",
+							["recipeID"] = 84412
+						}
+					}
 				}
 			}
 		},

--- a/contrib/Parser/DATAS/11 - Professions/Engineering/Recipes/_ Automation.lua
+++ b/contrib/Parser/DATAS/11 - Professions/Engineering/Recipes/_ Automation.lua
@@ -1570,10 +1570,6 @@ profession(202, {	-- Engineering
 					["categoryID"] = 739,
 					["g"] = {
 						{
-							["name"] = "De-Weaponized Mechanical Companion",
-							["recipeID"] = 84413
-						},
-						{
 							["name"] = "Electrostatic Condenser",
 							["recipeID"] = 95703
 						},
@@ -1600,10 +1596,6 @@ profession(202, {	-- Engineering
 						{
 							["name"] = "Lure Master Tackle Box",
 							["recipeID"] = 84415
-						},
-						{
-							["name"] = "Personal World Destroyer",
-							["recipeID"] = 84412
 						}
 					}
 				},


### PR DESCRIPTION
Those two engineering recipes where missing from the list of gnome and goblin engineering in my last pull request