### PR TITLE
Brewfest Legacy Quests

### DIFF
--- a/contrib/Parser/DATAS/21 - Holidays/07 - Brewfest/Legacy.lua
+++ b/contrib/Parser/DATAS/21 - Holidays/07 - Brewfest/Legacy.lua
@@ -7,23 +7,107 @@ _.Holidays = bubbleDown({["u"] = 24},
 		n(-40, {	-- Legacy
 			["g"] = {
 				n(-17, {	-- Quests
-					q(13931, {	-- Another Year, Another Souvenir.
+					q(11321, {	-- Did Someone Say "Souvenir?"  (A)
 						["providers"] = {
-							{ "n", 24497 },	-- Ram Master Ray
 							{ "n", 24468 },	-- Pol Amberstill
 						},
 						["coords"] = {
-							{ 42.6, 17.6, 1 },
 							{ 53.6, 38.6, 27 },
 						},
 						["u"] = 40,	-- Legacy Quests
 						["maps"] = {
+							27,	-- Dun Morogh
+						},
+						["g"] = {
+							un(2, i(32912)),	-- Yellow Brewfest Stein
+						},
+						["races"] = ALLIANCE_ONLY,
+						["isYearly"] = true,
+					}),
+					q(11413, {	-- Did Someone Say "Souvenir?"  (H)
+						["providers"] = {
+							{ "n", 24497 },	-- Ram Master Ray
+						},
+						["coords"] = {
+							{ 42.6, 17.6, 1 },
+						},
+						["u"] = 40,	-- Legacy Quests
+						["maps"] = {
 							1,	-- Durotar
+						},
+						["g"] = {
+							un(2, i(32912)),	-- Yellow Brewfest Stein
+						},
+						["races"] = HORDE_ONLY,
+						["isYearly"] = true,
+					}),
+					q(12193, {	-- Say, There Wouldn't Happen to be a Souvenir This Year, Would There? (A)
+						["providers"] = {
+							{ "n", 24468 },	-- Pol Amberstill
+						},
+						["coords"] = {
+							{ 53.6, 38.6, 27 },
+						},
+						["u"] = 40,	-- Legacy Quests
+						["maps"] = {
+							27,	-- Dun Morogh
+						},
+						["g"] = {
+							un(2, i(33016)),	-- Blue Brewfest Stein
+						},
+						["races"] = ALLIANCE_ONLY,
+						["isYearly"] = true,
+					}),
+					q(12194, {	-- Say, There Wouldn't Happen to be a Souvenir This Year, Would There? (H)
+						["providers"] = {
+							{ "n", 24497 },	-- Ram Master Ray
+						},
+						["coords"] = {
+							{ 42.6, 17.6, 1 },
+						},
+						["u"] = 40,	-- Legacy Quests
+						["maps"] = {
+							1,	-- Durotar
+						},
+						["g"] = {
+							un(2, i(33016)),	-- Blue Brewfest Stein
+						},
+						["races"] = HORDE_ONLY,
+						["isYearly"] = true,
+					}),
+					q(13932, {	-- Another Year, Another Souvenir (A)
+						["providers"] = {
+							{ "n", 24468 },	-- Pol Amberstill
+						},
+						["coords"] = {
+							{ 53.6, 38.6, 27 },
+						},
+						["u"] = 40,	-- Legacy Quests
+						["maps"] = {
 							27,	-- Dun Morogh
 						},
 						["g"] = {
 							un(2, i(37892)),	-- Green Brewfest Stein
 						},
+						["races"] = ALLIANCE_ONLY,
+						["isYearly"] = true,
+					}),
+					q(13931, {	-- Another Year, Another Souvenir (H)
+						["providers"] = {
+							{ "n", 24497 },	-- Ram Master Ray
+						},
+						["coords"] = {
+							{ 42.6, 17.6, 1 },
+						},
+						["u"] = 40,	-- Legacy Quests
+						["maps"] = {
+							1,	-- Durotar
+						},
+						["g"] = {
+							un(2, i(37892)),	-- Green Brewfest Stein
+						},
+						["races"] = HORDE_ONLY,
+						["isYearly"] = true,
 					}),
 					q(11454, {	-- Seek the Saboteurs
 						["u"] = 40,	-- Legacy Quests
@@ -37,6 +121,40 @@ _.Holidays = bubbleDown({["u"] = 24},
 								["u"] = 32,	-- Reworked Rewards
 							}),
 						},
+					}),
+					q(12020, {	-- This One Time, When I Was Drunk... (H)
+						["providers"] = {
+							{ "o", 189989 },	-- Dark Iron Mole Machine Wreckage
+						},
+						["coords"] = {
+							{ 56, 37.1, 1 },
+						},
+						["u"] = 40,	-- Legacy Quests
+						["maps"] = {
+							27,	-- Dun Morogh
+						},
+						["races"] = ALLIANCE_ONLY,
+						["isDaily"] = true,
+						["g"] = {
+								un(2, ach(1186)),	-- Down With The Dark Iron
+							},
+					}),
+					q(12192, {	-- This One Time, When I Was Drunk... (A)
+						["providers"] = {
+							{ "o", 189990 },	-- Dark Iron Mole Machine Wreckage
+						},
+						["coords"] = {
+							{ 40.7, 17.4, 1 },
+						},
+						["u"] = 40,	-- Legacy Quests
+						["maps"] = {
+							1,	-- Durotar
+						},
+						["races"] = HORDE_ONLY,
+						["isDaily"] = true,
+						["g"] = {
+								un(2, ach(1186)),	-- Down With The Dark Iron
+							},
 					}),
 					--[[
 					q(11486, {	-- The Best of Brews (Alliance)


### PR DESCRIPTION
Added legacy quests for old tankards

Did Someone Say "Souvenir?"  2007
Say, There Wouldn't Happen to be a Souvenir This Year, Would There?  2008
Another Year, Another Souvenir 2009-2010 Alliance version

I think all of this quest is marked as yearly in Blizzard database because I have the tankard from 2008 and 2009 but those quests were reset.

Also 
This One Time, When I Was Drunk... Daily Legacy