### PR TITLE
Missing ALLIANCE_ONLY in four Candy Bucket quests

### DIFF
--- a/contrib/Parser/DATAS/21 - Holidays/09 - Hallow's End/Quests.lua
+++ b/contrib/Parser/DATAS/21 - Holidays/09 - Hallow's End/Quests.lua
@@ -572,7 +572,7 @@ _.Holidays = bubbleDown({["u"] = 26},
 						}),
 					},
 				}),
-				q(13473, {	-- Candy Bucket — Dalaran : Northrend, Legerdemain Lounge, neutral
+				q(13463, {	-- Candy Bucket — Dalaran : Northrend, Legerdemain Lounge, neutral
 					["isYearly"] = true,
 					["coord"] = { 66.6, 30.1, 125 },
 					["maps"] = { 125 },	-- Dalaran : Northrend
@@ -583,7 +583,7 @@ _.Holidays = bubbleDown({["u"] = 26},
 						}),
 					},
 				}),
-				q(13463, {	-- Candy Bucket — Dalaran : Northrend, Silver Enclave, Alliance
+				q(13473, {	-- Candy Bucket — Dalaran : Northrend, Silver Enclave, Alliance
 					["isYearly"] = true,
 					["coord"] = { 42.5, 63.5, 125 },
 					["races"] = ALLIANCE_ONLY,
@@ -1288,6 +1288,7 @@ _.Holidays = bubbleDown({["u"] = 26},
 				q(12335, {	-- Candy Bucket — Ironforge, The Commons, Alliance
 					["isYearly"] = true,
 					["coord"] = { 18.6, 51.3, 87 },
+					["races"] = ALLIANCE_ONLY,
 					["maps"] = { 87 },	-- Ironforge
 					["u"] = 26,	-- Hallow's End
 					["g"] = {
@@ -1516,6 +1517,7 @@ _.Holidays = bubbleDown({["u"] = 26},
 				q(28963, {	-- Candy Bucket — Loch Modan, Farstrider Lodge, Alliance
 					["isYearly"] = true,
 					["coord"] = { 82.9, 63.6, 48 },
+					["races"] = ALLIANCE_ONLY,
 					["maps"] = { 48 },	-- Loch Modan
 					["u"] = 26,	-- Hallow's End
 					["g"] = {
@@ -2060,6 +2062,7 @@ _.Holidays = bubbleDown({["u"] = 26},
 				q(12336, {	-- Candy Bucket — Stormwind, The Trade District, Alliance
 					["isYearly"] = true,
 					["coord"] = { 60.5, 75.2, 84 },
+					["races"] = ALLIANCE_ONLY,
 					["maps"] = { 84 },	-- Stormwind City
 					["u"] = 26,	-- Hallow's End
 					["g"] = {

--- a/contrib/Parser/DATAS/21 - Holidays/09 - Hallow's End/Quests.lua
+++ b/contrib/Parser/DATAS/21 - Holidays/09 - Hallow's End/Quests.lua
@@ -574,7 +574,7 @@ _.Holidays = bubbleDown({["u"] = 26},
 				}),
 				q(13463, {	-- Candy Bucket — Dalaran : Northrend, Legerdemain Lounge, neutral
 					["isYearly"] = true,
-					["coord"] = { 66.6, 30.1, 125 },
+					["coord"] = { 48.3, 40.8, 125 },
 					["maps"] = { 125 },	-- Dalaran : Northrend
 					["u"] = 26,	-- Hallow's End
 					["g"] = {
@@ -597,7 +597,7 @@ _.Holidays = bubbleDown({["u"] = 26},
 				}),
 				q(13474, {	-- Candy Bucket — Dalaran : Northrend, Sunreaver's Sanctuary, Horde
 					["isYearly"] = true,
-					["coord"] = { 48.3, 40.8, 125 },
+					["coord"] = { 66.6, 30.1, 125 },
 					["races"] = HORDE_ONLY,
 					["maps"] = { 125 },	-- Dalaran : Northrend
 					["u"] = 26,	-- Hallow's End

--- a/contrib/Parser/DATAS/21 - Holidays/09 - Hallow's End/Quests.lua
+++ b/contrib/Parser/DATAS/21 - Holidays/09 - Hallow's End/Quests.lua
@@ -595,7 +595,7 @@ _.Holidays = bubbleDown({["u"] = 26},
 						}),
 					},
 				}),
-				q(13463, {	-- Candy Bucket — Dalaran : Northrend, Sunreaver's Sanctuary, Horde
+				q(13474, {	-- Candy Bucket — Dalaran : Northrend, Sunreaver's Sanctuary, Horde
 					["isYearly"] = true,
 					["coord"] = { 48.3, 40.8, 125 },
 					["races"] = HORDE_ONLY,


### PR DESCRIPTION
Also Northrend Dalaran Neutral and Alliance Candy Buckets had the wrong quest id

With this change Hollow End can be 100% completed by Horde characters, I am not sure about Alliance because I have not completed all candy bucket quests with an alliance character to check if some horde only quest is missing Horde Only mark