### PR TITLE
Some more quests added for issue #398

### DIFF
--- a/contrib/Parser/DATAS/02 - Outdoor Zones/01 Kalimdor/Durotar/Quests.lua
+++ b/contrib/Parser/DATAS/02 - Outdoor Zones/01 Kalimdor/Durotar/Quests.lua
@@ -80,6 +80,9 @@ _.Zones =
 						un(2, i(7129)),	-- Brutal Gauntlets
 					},
 				}),
+				q(832, {	-- Burning Shadows
+					["u"] = 40,	-- Legacy Quests
+				}),
 				q(25924, {	-- Call of Duty
 					["provider"] = { "n", 41621 },	-- Commander Thorak
 					["coord"] = { 55.9, 12.3, 1 },
@@ -505,6 +508,16 @@ _.Zones =
 					["coord"] = { 35.8, 41.3, 1 },
 					["races"] = HORDE_ONLY,
 					["sourceQuest"] = 25194,	-- Unbidden Visitors
+				}),
+				q(830, {	-- The Admiral's Orders
+					["provider"] = { "i", 4881 },	-- A Letter to Yvette
+					["races"] = HORDE_ONLY,
+					["u"] = 40,	-- Legacy Quests
+				}),
+				q(831, {	-- The Admiral's Orders
+					["provider"] = { "n", 3139 },	-- A Letter to Yvette
+					["races"] = HORDE_ONLY,
+					["u"] = 40,	-- Legacy Quests
 				}),
 				q(40518, {	-- The Battle for Broken Shore
 					["provider"] = { "n", 113547 },	-- Stone Guard Mukar

--- a/contrib/Parser/DATAS/02 - Outdoor Zones/01 Kalimdor/Northern Barrens/Quests.lua
+++ b/contrib/Parser/DATAS/02 - Outdoor Zones/01 Kalimdor/Northern Barrens/Quests.lua
@@ -475,6 +475,11 @@ _.Zones =
 						i(131218),	-- Cord of the Forgotten Pool
 					},
 				}),
+				q(883, {	-- Lakota'mani
+					["provider"] = { "i", 5099 },	-- Hoof of Lakota'mani
+					["races"] = HORDE_ONLY,
+					["u"] = 40,	-- Legacy Quests
+				}),
 				q(14038, {	-- Love it or Limpet
 					["provider"] = { "n", 3391 },	-- Gazlowe
 					["coord"] = { 68.4, 69.0, 10 },
@@ -1033,6 +1038,11 @@ _.Zones =
 						i(59565),	-- Waptor Scale Bweastpwate
 						i(131332),	-- Waptor Tweads
 					},
+				}),
+				q(885, {	-- Washte Pawne
+					["provider"] = { "i", 5103 },	-- Washte Pawne's Feather
+					["races"] = HORDE_ONLY,
+					["u"] = 40,	-- Legacy Quests
 				}),
 				q(29026, {	-- Wenikee Boltbucket
 					["provider"] = { "n", 34674 },	-- Brak Blusterpipe

--- a/contrib/Parser/DATAS/02 - Outdoor Zones/02 Eastern Kingdoms/Arathi Highlands/Quests.lua
+++ b/contrib/Parser/DATAS/02 - Outdoor Zones/02 Eastern Kingdoms/Arathi Highlands/Quests.lua
@@ -100,6 +100,10 @@ _.Zones =
 					["races"] = HORDE_ONLY,
 					["sourceQuest"] = 26912,	-- The Princess Unleashed (TODO: verify. Didn't see this until after killing Myzrael)
 				}),
+				q(635, {	-- Crystal in the Mountains
+					["races"] = HORDE_ONLY,
+					["u"] = 40,	-- Legacy Quests
+				}),
 				q(42535, {	-- Death... and Decay
 					["provider"] = { "n", 107806 },	-- Prince Galen Trollbane
 					["lvl"] = 100,
@@ -258,6 +262,10 @@ _.Zones =
 					["coord"] = { 54.8, 55.4, 14 },
 					["races"] = ALLIANCE_ONLY,
 					["sourceQuest"] = 26114,	-- Quae Trusts You
+				}),
+				q(663, {	-- Land Ho!
+					["provider"] = { "n", 2766 },	-- Lolo the Lookout
+					["u"] = 40,	-- Legacy Quests
 				}),
 				q(697,   {	-- Malin's Request
 					["u"] = 40,
@@ -440,12 +448,24 @@ _.Zones =
 						un(2, i(4743)),	-- Pulsating Crystalline Shard
 					},
 				}),
+				q(665, {	-- Sunken Treasure
+					["u"] = 40,
+				}),
 				q(666,   {	-- Sunken Treasure
 					["u"] = 40,
 					["g"] = {
 						un(2, i(4547)),	-- Gnomish Zapper
 						un(2, i(4548)),	-- Servomechanic Sledgehammer
 					},
+				}),
+				q(668, {	-- Sunken Treasure
+					["u"] = 40,
+				}),
+				q(669, {	-- Sunken Treasure
+					["u"] = 40,
+				}),
+				q(670, {	-- Sunken Treasure
+					["u"] = 40,
 				}),
 				q(26051, {	-- Sunken Treasure
 					["provider"] = { "n", 2774 },	-- Doctor Draxlegauge

--- a/contrib/Parser/DATAS/02 - Outdoor Zones/02 Eastern Kingdoms/Hillsbrad Foothills/Quests.lua
+++ b/contrib/Parser/DATAS/02 - Outdoor Zones/02 Eastern Kingdoms/Hillsbrad Foothills/Quests.lua
@@ -821,6 +821,11 @@ _.Zones =
 					["classes"] = { 8 },	-- Mage
 					["sourceQuests"] = { 40270 },	-- The Path of Atonement
 				}),
+				q(676, {	-- The Hammer May Fall
+					["provider"] = { "n", 2770 },	-- Tallow
+					["races"] = HORDE_ONLY,
+					["u"] = 40,	-- Legacy Quests
+				}),
 				q(28484, {	-- The Heart of the Matter
 					["provider"] = { "n", 2437 },	-- Keeper Bel'varil
 					["coord"] = { 56.9, 45.7, 25 },

--- a/contrib/Parser/DATAS/02 - Outdoor Zones/02 Eastern Kingdoms/Northern Stranglethorn/Quests.lua
+++ b/contrib/Parser/DATAS/02 - Outdoor Zones/02 Eastern Kingdoms/Northern Stranglethorn/Quests.lua
@@ -434,6 +434,9 @@ _.Zones =
 						29229,	-- Follow That Cat (recently disturbed dirt mound)
 					},
 				}),
+				q(594, {	-- Message in a Bottle
+					["u"] = 40,	-- Legacy Quests
+				}),
 				q(26774, {	-- Mind Control (A)
 					["provider"] = { "n", 44017 },	-- Priestess Thaalia
 					["coord"] = { 53.4, 66.7, 50 },
@@ -785,6 +788,9 @@ _.Zones =
 						un(2, i(7985)),	-- Plans: Ornate Mithril Shoulders
 					},
 				}),
+				q(615, {	-- The Captain's Cutlass
+					["u"] = 40,	-- Legacy Quests
+				}),
 				q(569,   {	-- The Defense of Grom'gol
 					["u"] = 40,
 					["races"] = HORDE_ONLY,
@@ -911,6 +917,9 @@ _.Zones =
 						2757,	-- Booty Bay or Bust! (Horde)
 						2759,	-- In Search of Galvan (Alliance)
 					},
+				}),
+				q(620, {	-- The Monogrammed Sash
+					["u"] = 40,	-- Legacy Quests
 				}),
 				q(26782, {	-- The Mosh'Ogg Bounty (A) -- TODO:: how is this version obtained?
 					["provider"] = { "n", 44017 },	-- Wulfred Harrys

--- a/contrib/Parser/DATAS/02 - Outdoor Zones/02 Eastern Kingdoms/Tirisfal Glades/Quests.lua
+++ b/contrib/Parser/DATAS/02 - Outdoor Zones/02 Eastern Kingdoms/Tirisfal Glades/Quests.lua
@@ -24,6 +24,11 @@ _.Zones =
 					["races"] = HORDE_ONLY,
 					["sourceQuests"] = { 25009 },	-- At War With The Scarlet Crusade
 				}),
+				q(361, {	-- A Letter Undelivered
+					["provider"] = { "i", 2839 },	-- A Letter to Yvette
+					["races"] = HORDE_ONLY,
+					["u"] = 40,	-- Legacy Quests
+				}),
 				q(25013, {	-- A Little Oomph
 					["provider"] = { "n", 11057 },	-- Apothecary Dithers
 					["coord"] = { 83.2, 69.2, 18 },
@@ -83,6 +88,10 @@ _.Zones =
 					["lvl"] = 5,
 					["races"] = HORDE_ONLY,
 					["provider"] = { "n", 6784 },	-- Calvin Montague
+				}),
+				q(590, {	-- A Rogue's Deal
+					["races"] = HORDE_ONLY,
+					["u"] = 40,	-- Legacy Quests
 				}),
 				q(24979, {	-- A Scarlet Letter
 					["crs"] = { 1535 },	-- Scarlet Warrior


### PR DESCRIPTION
361 -- A Letter Undelivered (Legacy)
590 -- A Rogue's Deal (Legacy)
594 -- Message in a Bottle (Legacy)
615 -- The Captain's Cutlass (Legacy)
620 -- The Monogrammed Sash (Legacy)
635 -- Crystal in the Mountains (Legacy)
663 -- Land Ho! (Legacy)
665 -- Sunken Treasure (Legacy)
668 -- Sunken Treasure (Legacy)
669 -- Sunken Treasure (Legacy)
670 -- Sunken Treasure (Legacy)
676 -- The Hammer May Fall (Legacy)
830 -- The Admiral's Orders (Legacy)
831 -- The Admiral's Orders (Legacy)
832 -- Burning Shadows (Legacy)
883 -- Lakota'mani (Legacy)
885 -- Washte Pawne (Legacy)