### PR TITLE
Some more quests added for issue #398

### DIFF
--- a/contrib/Parser/DATAS/02 - Outdoor Zones/01 Kalimdor/02 Orgrimmar/Quests.lua
+++ b/contrib/Parser/DATAS/02 - Outdoor Zones/01 Kalimdor/02 Orgrimmar/Quests.lua
@@ -1099,6 +1099,11 @@ _.Zones =
 					["lvl"] = 45,
 					["u"] = 40,
 				}),
+				q(1947, {	-- Journey to the Marsh
+					["races"] = HORDE_ONLY,
+					["u"] = 40,	-- Legacy Quests
+					["classes"] = { 8 },	-- Mage
+				}),
 				q(8944,  {	-- Just Compensation (Warrior)
 					["provider"] = { "n", 16012 },	-- Mokvar
 					["coord"] = { 48.6, 72.8, 85 },
@@ -1215,6 +1220,11 @@ _.Zones =
 						un(2, i(22106)), 	-- Feralheart Belt
 						un(2, i(22110)), 	-- Feralheart Gloves
 					},
+				}),
+				q(1945, {	-- Laughing Sisters
+					["races"] = HORDE_ONLY,
+					["u"] = 40,	-- Legacy Quests
+					["classes"] = { 8 },	-- Mage
 				}),
 				q(32673, {	-- Learn To Ride
 					["description"] = "This quest is available to Goblins upon reaching level 20.",
@@ -1933,6 +1943,11 @@ _.Zones =
 						i(63924),	-- Blade-Dodging Girdle
 						i(63923),	-- Hauberk of Shock
 					},
+				}),
+				q(1944, {	-- Waters of Xavian
+					["races"] = HORDE_ONLY,
+					["u"] = 40,	-- Legacy Quests
+					["classes"] = { 8 },	-- Mage
 				}),
 				q(28466, {	-- Weapons of Darkness
 					["provider"] = { "n", 44725 },	-- Sunwalker Atohmo

--- a/contrib/Parser/DATAS/02 - Outdoor Zones/01 Kalimdor/Durotar/Quests.lua
+++ b/contrib/Parser/DATAS/02 - Outdoor Zones/01 Kalimdor/Durotar/Quests.lua
@@ -250,6 +250,15 @@ _.Zones =
 					["coord"] = { 45.6, 12.6, 1 },
 					["races"] = { 24 },	-- Pandaren (Neutral)
 				}),
+				q(1884, {	-- Ju-Ju Heaps
+					["races"] = HORDE_ONLY,
+					["u"] = 40,	-- Legacy Quests
+					["classes"] = { 8 },	-- Mage
+					["g"] = {
+						i(9513),	-- Ley Staff
+						i(7508),	-- Ley Orb
+					},
+				}),
 				q(40605, {	-- Keep Your Friends Close
 					["coord"] = { 45.6, 15.9, 1 },
 					["provider"] = { "n", 101035 },	-- Lady Sylvanas Windrunner
@@ -490,6 +499,11 @@ _.Zones =
 						i(53390),	-- Skull Rock Belt
 						i(131414),	-- Burning Armbands
 					},
+				}),
+				q(1883, {	-- Speak with Un'thuwa
+					["races"] = HORDE_ONLY,
+					["u"] = 40,	-- Legacy Quests
+					["classes"] = { 8 },	-- Mage
 				}),
 				q(25177, {	-- Storming the Beaches
 					["provider"] = { "n", 3139 },	-- Gar'Thok

--- a/contrib/Parser/DATAS/02 - Outdoor Zones/01 Kalimdor/Dustwallow Marsh/Quests.lua
+++ b/contrib/Parser/DATAS/02 - Outdoor Zones/01 Kalimdor/Dustwallow Marsh/Quests.lua
@@ -300,6 +300,11 @@ _.Zones =
 					["races"] = HORDE_ONLY,
 					["isBreadcrumb"] = true,
 				}),
+				q(1949, {	-- Hidden Secrets
+					["races"] = HORDE_ONLY,
+					["u"] = 40,	-- Legacy Quests
+					["classes"] = { 8 },	-- Mage
+				}),
 				q(1135,  {	-- Highperch Venom
 					["u"] = 40,
 					["provider"] = { "n", 4456 },	-- Fiora Longears
@@ -364,6 +369,11 @@ _.Zones =
 					["coord"] = { 69.3, 51.9, 70 },
 					["races"] = ALLIANCE_ONLY,
 					["sourceQuests"] = { 27218 },	-- Dastardly Denizens of the Deep
+				}),
+				q(1948, {	-- Items of Power
+					["races"] = HORDE_ONLY,
+					["u"] = 40,	-- Legacy Quests
+					["classes"] = { 8 },	-- Mage
 				}),
 				q(27238, {	-- Jaina Must Know
 					["provider"] = { "n", 23569 },	-- Renn McGill
@@ -454,6 +464,11 @@ _.Zones =
 						un(2, i(11263)),	-- Nether Force Wand
 						un(2, i(7513)),	-- Ragefire Wand
 					},
+				}),
+				q(1957, {	-- Mana Surges
+					["races"] = HORDE_ONLY,
+					["u"] = 40,	-- Legacy Quests
+					["classes"] = { 8 },	-- Mage
 				}),
 				q(27183, {	-- Marsh Frog Legs
 					["provider"] = { "n", 4792 },	-- "Swamp Eye" Jarl
@@ -564,6 +579,11 @@ _.Zones =
 						i(156976),	-- Staff of Memory
 					},
 				}),
+				q(1956, {	-- Power in Uldaman
+					["races"] = HORDE_ONLY,
+					["u"] = 40,	-- Legacy Quests
+					["classes"] = { 8 },	-- Mage
+				}),
 				q(27245, {	-- Prisoners of the Grimtotems (awarded "Prisoners of the Grimtotem" criteria)
 					["provider"] = { "n", 23723 },	-- Sergeant Lukas
 					["coord"] = { 46.5, 22.9, 70 },
@@ -666,6 +686,11 @@ _.Zones =
 						i(33267),	-- Fleshripper NOTE: This item is now available from Recover the Cargo or the new version of Return to Krog
 						un(2, i(33270)),	-- Mariner's Sword
 					},
+				}),
+				q(1953, {	-- Return to the Marsh
+					["races"] = HORDE_ONLY,
+					["u"] = 40,	-- Legacy Quests
+					["classes"] = { 8 },	-- Mage
 				}),
 				q(27236, {	-- Secondhand Diving Gear
 					["provider"] = { "n", 23569 },	-- Renn McGill
@@ -984,6 +1009,11 @@ _.Zones =
 					["coord"] = { 41.8, 73.9, 70 },
 					["sourceQuest"] = 27407,	-- Bloodfen Feathers
 				}),
+				q(1955, {	-- The Exorcism
+					["races"] = HORDE_ONLY,
+					["u"] = 40,	-- Legacy Quests
+					["classes"] = { 8 },	-- Mage
+				}),
 				q(27293, {	-- The Grimtotem Plot
 					["provider"] = { "n", 4926 },	-- Krog
 					["coord"] = { 36.4, 31.8, 70 },
@@ -1017,6 +1047,11 @@ _.Zones =
 					["coord"] = { 37.1, 33.0, 70 },
 					["races"] = HORDE_ONLY,
 					["isBreadcrumb"] = true,	-- for "Marsh Frog Legs"
+				}),
+				q(1954, {	-- The Infernal Orb
+					["races"] = HORDE_ONLY,
+					["u"] = 40,	-- Legacy Quests
+					["classes"] = { 8 },	-- Mage
 				}),
 				q(1238,  {	-- The Lost Report
 					["u"] = 40,

--- a/contrib/Parser/DATAS/02 - Outdoor Zones/01 Kalimdor/Stonetalon Mountains/Quests.lua
+++ b/contrib/Parser/DATAS/02 - Outdoor Zones/01 Kalimdor/Stonetalon Mountains/Quests.lua
@@ -376,9 +376,14 @@ _.Zones =
 						un(2, i(6667)),	-- Engineer's Cloak
 					},
 				}),
+				q(1090, {	-- Gerenzo's Orders
+					["u"] = 40,	-- Legacy Quests
+					["races"] = HORDE_ONLY,
+				}),
 				q(1092,  {	-- Gerenzo's Orders
-					["u"] = 40,
+					["u"] = 40,	-- Legacy Quests
 					["provider"] = { "n", 4276 },	-- Piznik
+					["races"] = HORDE_ONLY,
 					["g"] = {
 						un(2, i(6666)),	-- Dredge Boots
 					},

--- a/contrib/Parser/DATAS/02 - Outdoor Zones/01 Kalimdor/Thousand Needles/Quests.lua
+++ b/contrib/Parser/DATAS/02 - Outdoor Zones/01 Kalimdor/Thousand Needles/Quests.lua
@@ -383,6 +383,14 @@ _.Zones =
 					["provider"] = { "n", 4452 },	-- Kravel Koalbeard
 					["sourceQuest"] = 1119,	-- Zanzil's Mixture and a Fool's Stout
 				}),
+				q(1121, {	-- Get the Goblins Drunk
+					["u"] = 40,	-- Legacy Quests
+				}),
+				q(1950, {	-- Get the Scoop
+					["races"] = HORDE_ONLY,
+					["u"] = 40,	-- Legacy Quests
+					["classes"] = { 8 },	-- Mage
+				}),
 				q(25756, {	-- Get Zherin!
 					["provider"] = { "n", 41190 },	-- Crazzle Sprysprocket
 					["coord"] = { 91.4, 57.6, 64 },
@@ -714,6 +722,11 @@ _.Zones =
 						1120,	-- Get the Gnomes Drunk
 						1121,	-- Get the Goblins Drunk
 					},
+				}),
+				q(1951, {	-- Rituals of Power
+					["races"] = HORDE_ONLY,
+					["u"] = 40,	-- Legacy Quests
+					["classes"] = { 8 },	-- Mage
 				}),
 				q(1194,  {	-- Rizzle's Schematics
 					["u"] = 40,

--- a/contrib/Parser/DATAS/02 - Outdoor Zones/02 Eastern Kingdoms/1 - Undercity/Quests.lua
+++ b/contrib/Parser/DATAS/02 - Outdoor Zones/02 Eastern Kingdoms/1 - Undercity/Quests.lua
@@ -209,6 +209,11 @@ _.Zones =
 						un(2, i(4984)),	-- Skull of Impending Doom
 					},
 				}),
+				q(1961, {	-- Gathering Materials
+					["races"] = HORDE_ONLY,
+					["u"] = 40,	-- Legacy Quests
+					["classes"] = { 8 },	-- Mage
+				}),
 				q(1109,  {	-- Going, Going, Guano
 					["u"] = 40,
 					["races"] = HORDE_ONLY,
@@ -271,6 +276,11 @@ _.Zones =
 						un(2, i(6803)),	-- Prophetic Cane
 						un(2, i(6802)),	-- Sword of Omen
 					},
+				}),
+				q(1960, {	-- Investigate the Alchemist Shop
+					["races"] = HORDE_ONLY,
+					["u"] = 40,	-- Legacy Quests
+					["classes"] = { 8 },	-- Mage
 				}),
 				q(27335, {	-- Journey to Orgrimmar
 					["provider"] = { "n", 4606 },	-- Aelthalyste
@@ -456,6 +466,11 @@ _.Zones =
 					["u"] = 40,
 					["races"] = HORDE_ONLY,
 					["provider"] = { "n", 5651 },	-- Patrick Garrett
+				}),
+				q(1959, {	-- Report to Anastasia
+					["races"] = HORDE_ONLY,
+					["u"] = 40,	-- Legacy Quests
+					["classes"] = { 8 },	-- Mage
 				}),
 				q(366,   {	-- Return the Book
 					["u"] = 40,

--- a/contrib/Parser/DATAS/02 - Outdoor Zones/02 Eastern Kingdoms/Badlands/Quests.lua
+++ b/contrib/Parser/DATAS/02 - Outdoor Zones/02 Eastern Kingdoms/Badlands/Quests.lua
@@ -197,6 +197,13 @@ _.Zones =
 					["coord"] = { 66.3, 55.4, 15 },
 					["sourceQuests"] = { 27764 },	-- A Strange Request
 				}),
+				q(1559, {	-- Flash Bomb Recipe
+					["requireSkill"] = 202,	-- Engineering
+					["u"] = 40,	-- Legacy Quests
+					["g"] = {
+						i(6672),	-- Schematic: Flash Bomb
+					},
+				}),
 				q(27878, {	-- Forcible Acquisition
 					["provider"] = { "n", 46758 },	-- Aoren Sunglow
 					["coord"] = { 52.1, 51.5, 15 }, 

--- a/contrib/Parser/DATAS/02 - Outdoor Zones/02 Eastern Kingdoms/Duskwood/Quests.lua
+++ b/contrib/Parser/DATAS/02 - Outdoor Zones/02 Eastern Kingdoms/Duskwood/Quests.lua
@@ -310,6 +310,13 @@ _.Zones =
 					["races"] = HORDE_ONLY,
 					["provider"] = { "n", 5418 },	-- Deathstalker Zraedus
 				}),
+				q(1388, {	-- Nothing But The Truth
+					["sourceQuest"] = 1372,	-- Nothing But The Truth
+					["u"] = 40,	-- Legacy Quests
+				}),
+				q(1391, {	-- Nothing But The Truth
+					["u"] = 40,	-- Legacy Quests
+				}),
 				q(26680, {	-- Ogre Thieves
 					["provider"] = { "n", 289 },	-- Abercrombie
 					["coord"] = { 87.4, 35.2, 47 },

--- a/contrib/Parser/DATAS/02 - Outdoor Zones/02 Eastern Kingdoms/Swamp of Sorrows/Quests.lua
+++ b/contrib/Parser/DATAS/02 - Outdoor Zones/02 Eastern Kingdoms/Swamp of Sorrows/Quests.lua
@@ -277,6 +277,9 @@ _.Zones =
 					["races"] = HORDE_ONLY,
 					["sourceQuest"] = 27857,	-- We're Under Attack!
 				}),
+				q(1392, {	-- Noboru the Cudgel
+					["u"] = 40,	-- Legacy Quests
+				}),
 				q(28553, {	-- Okrilla and the Blasted Lands
 					["provider"] = { "n", 7623 },	-- Dispatch Commander Ruag
 					["coord"] = { 49.3, 55.3, 51 },

--- a/contrib/Parser/DATAS/06 - Expansion Features/06 Legion Class Halls/The Wandering Isle (Monk).lua
+++ b/contrib/Parser/DATAS/06 - Expansion Features/06 Legion Class Halls/The Wandering Isle (Monk).lua
@@ -42,6 +42,10 @@ _.ExpansionFeatures =
 						["provider"] = { "n", 117305 },	-- Brewer Almai
 						["sourceQuests"] = { 45459 },	-- Storming the Legion
 					}),
+					q(41911, {	-- Amaranthine Hops
+						["provider"] = { "n", 102996 },	-- Aegira (Broken Temple Brewmaster)
+						["sourceQuests"] = { 41039 },	-- Stolen Knowledge
+					}),
 					q(45545, {	-- Barrel Toss
 						["provider"] = { "n", 117305 },	-- Brewer Almai
 						["sourceQuests"] = { 45459 },	-- Storming the Legion
@@ -194,7 +198,6 @@ _.ExpansionFeatures =
 					q(43359),	-- A Hero's Weapon
 					q(40793),	-- A Matter of Planning
 					q(41086),	-- A Peaceful World
-					q(41911),	-- Amaranthine Hops
 					q(43054),	-- An Ample Stockpile
 					q(45180),	-- An Island of War
 					q(46024),	-- An Urgent Warning


### PR DESCRIPTION
1090 -- Gerenzo's Orders (Legacy)
1121 -- Get the Goblins Drunk (Legacy)
1388 -- Nothing But The Truth (Legacy)
1391 -- Nothing But The Truth (Legacy)
1392 -- Noboru the Cudgel (Legacy)
1559 -- Flash Bomb Recipe (Legacy, Engineering)
1883 -- Speak with Un'thuwa (Legacy, Mage)
1884 -- Ju-Ju Heaps (Legacy, Mage)
1944 -- Waters of Xavian (Legacy, Mage)
1945 -- Laughing Sisters (Legacy, Mage)
1947 -- Journey to the Marsh (Legacy, Mage)
1948 -- Items of Power (Legacy, Mage)
1949 -- Hidden Secrets (Legacy, Mage)
1950 -- Get the Scoop (Legacy, Mage)
1951 -- Rituals of Power (Legacy, Mage)
1953 -- Return to the Marsh (Legacy, Mage)
1954 -- The Infernal Orb (Legacy, Mage)
1955 -- The Exorcism (Legacy, Mage)
1956 -- Power in Uldaman (Legacy, Mage)
1957 -- Mana Surges (Legacy, Mage)
1959 -- Report to Anastasia (Legacy, Mage)
1960 -- Investigate the Alchemist Shop (Legacy, Mage)
41911 -- Amaranthine Hops (Monk Class Campaign)

Parsed without issues.