### PR TITLE
ATT WorldQuests Modification

### DIFF
--- a/.contrib/Parser/_main.lua
+++ b/.contrib/Parser/_main.lua
@@ -765,7 +765,7 @@ a = function(t)	-- Flag as Alliance Only
 				local count = 0;
 				for j,value2 in ipairs(value) do
 					if count > 0 then statement = statement .. ", "; end
-					statement = statement .. tostring(valu2);
+					statement = statement .. tostring(value2);
 					count = count + 1;
 				end
 				print("\t" .. tostring(key) .. ": { " .. statement .. " }");

--- a/AllTheThings.lua
+++ b/AllTheThings.lua
@@ -50,23 +50,24 @@ app.RawData = {};
 app.refreshing = {};
 local function OnUpdate(self)
 	for i=#self.__stack,1,-1 do
+		-- print("Running Stack " .. i .. ":" .. self.__stack[i][2])
 		if not self.__stack[i][1](self) then
+			-- print("Removing Stack " .. i .. ":" .. self.__stack[i][2])
 			table.remove(self.__stack, i);
-			if #self.__stack < 1 then
-				self:SetScript("OnUpdate", nil);
-			end
 		end
+	end
+	-- Stop running OnUpdate if nothing in the Stack to process
+	if #self.__stack < 1 then
+		self:SetScript("OnUpdate", nil);
 	end
 end
 local function Push(self, name, method)
 	if not self.__stack then
 		self.__stack = {};
-		self:SetScript("OnUpdate", OnUpdate);
-	elseif #self.__stack < 1 then 
-		self:SetScript("OnUpdate", OnUpdate);
 	end
 	--print("Push->" .. name);
 	table.insert(self.__stack, { method, name });
+	self:SetScript("OnUpdate", OnUpdate);
 end
 local function StartCoroutine(name, method)
 	if method and not app.refreshing[name] then
@@ -1874,6 +1875,7 @@ ResolveSymbolicLink = function(o)
 		local searchResults, finalized = {}, {};
 		for j,sym in ipairs(o.sym) do
 			local cmd = sym[1];
+			-- print("Resolving Symbolic Link using '" .. tostring(cmd) .. "' with [" .. tostring(sym[2]) .. "] & [" .. tostring(sym[3]) .. "]")
 			if cmd == "select" then
 				-- Instruction to search the full database for something.
 				local cache = app.SearchForField(sym[2], sym[3]);
@@ -3493,6 +3495,7 @@ local function ExportData(group)
 	end
 end
 local function RefreshSavesCoroutine()
+	-- TODO: this coroutine ran "forever" (5+ minutes) on a vulpera when I logged in, may need to test further...
 	local waitTimer = 30;
 	while waitTimer > 0 do
 		coroutine.yield();
@@ -12633,7 +12636,7 @@ app:GetWindow("WorldQuests", UIParent, function(self)
 						['description'] = "Sometimes the World Quest API is slow or fails to return new data. If you wish to forcibly refresh the data without changing zones, click this button now!",
 						['hash'] = "funUpdateWorldQuests",
 						['OnClick'] = function(data, button)
-							Push(self, "Rebuild", self.Rebuild);
+							Push(self, "WorldQuests-Rebuild", self.Rebuild);
 							return true;
 						end,
 						['OnUpdate'] = function(data) 
@@ -12716,7 +12719,8 @@ app:GetWindow("WorldQuests", UIParent, function(self)
 				wipe(self.data.g);
 				wipe(self.rawData);
 				tinsert(self.data.g, temp);
-				self:Rebuild();
+				-- self:Rebuild(); -- clearing data probably shouldn't include putting it all back...
+				self:Update();
 			end
 			self.Rebuild = function(self, no)
 				-- Rebuild all World Quest data
@@ -12727,6 +12731,7 @@ app:GetWindow("WorldQuests", UIParent, function(self)
 				-- Acquire all of the emissary quests
 				for _,pair in ipairs(emissaryMapIDs) do
 					local mapID = pair[1];
+					-- print("WQ.EmissaryMapIDs." .. tostring(mapID))
 					local mapObject = { mapID=mapID,g={},progress=0,total=0};
 					local cache = fieldCache["mapID"][mapID];
 					if cache then
@@ -12775,9 +12780,10 @@ app:GetWindow("WorldQuests", UIParent, function(self)
 					end
 				end
 				
-				-- Acquire all of the world quests.
+				-- Acquire all of the world quests
 				for _,pair in ipairs(worldMapIDs) do
 					local mapID = pair[1];
+					-- print("WQ.WorldMapIDs." .. tostring(mapID))
 					local mapObject = { mapID=mapID,g={},progress=0,total=0};
 					local cache = fieldCache["mapID"][mapID];
 					if cache then
@@ -12839,9 +12845,12 @@ app:GetWindow("WorldQuests", UIParent, function(self)
 											end
 										end
 										
-										local numQuestRewards = GetNumQuestLogRewards (questObject.questID);
+										local numQuestRewards = GetNumQuestLogRewards(questObject.questID);
+										-- numQuestRewards will often be 0 for fresh questID API calls
+										-- pre-emptively call the following API method as well to get cached data earlier for the next refresh
+										local _ = GetQuestLogRewardInfo(1, questObject.questID);
 										for j=1,numQuestRewards,1 do
-											local _, _, _, _, _, itemID, ilvl = GetQuestLogRewardInfo (j, questObject.questID);
+											local _, _, _, _, _, itemID, ilvl = GetQuestLogRewardInfo(j, questObject.questID);
 											if itemID then
 												if showCurrencies or (itemID ~= 116415 and itemID ~= 163036) then
 													QuestHarvester.AllTheThingsProcessing = true;
@@ -12907,7 +12916,7 @@ app:GetWindow("WorldQuests", UIParent, function(self)
 													end
 												end
 											else
-												return true;
+												retry = true;
 											end
 										end
 										
@@ -13029,6 +13038,9 @@ app:GetWindow("WorldQuests", UIParent, function(self)
 							end
 							
 							local numQuestRewards = GetNumQuestLogRewards (questObject.questID);
+							-- numQuestRewards will often be 0 for fresh questID API calls...
+							-- pre-emptively call the following API method as well to get cached data earlier for the next refresh
+							local _ = GetQuestLogRewardInfo(1, questObject.questID);
 							for j=1,numQuestRewards,1 do
 								local _, _, _, _, _, itemID, ilvl = GetQuestLogRewardInfo (j, questObject.questID);
 								if itemID then
@@ -13096,7 +13108,7 @@ app:GetWindow("WorldQuests", UIParent, function(self)
 										end
 									end
 								else
-									return true;
+									retry = true;
 								end
 							end
 							
@@ -13117,26 +13129,27 @@ app:GetWindow("WorldQuests", UIParent, function(self)
 							
 							if showCurrencies then
 								local numCurrencies = GetNumQuestLogRewardCurrencies(questObject.questID);
-								if numCurrencies > 0 then
-									for j=1,numCurrencies,1 do
-										local name, texture, numItems, currencyID = GetQuestLogRewardCurrencyInfo(j, questObject.questID);
-										if currencyID then
-											local item = { ["currencyID"] = currencyID, ["expanded"] = false, };
-											cache = fieldCache["currencyID"][currencyID];
-											if cache then
-												for _,data in ipairs(cache) do
-													if data.f then
-														item.f = data.f;
+								-- numCurrencies will often be 0 for fresh questID API calls...
+								-- pre-emptively call the following API method as well to get cached data earlier for the next refresh
+								local _ = GetQuestLogRewardCurrencyInfo(1, questObject.questID);
+								for j=1,numCurrencies,1 do
+									local name, texture, numItems, currencyID = GetQuestLogRewardCurrencyInfo(j, questObject.questID);
+									if currencyID then
+										local item = { ["currencyID"] = currencyID, ["expanded"] = false, };
+										cache = fieldCache["currencyID"][currencyID];
+										if cache then
+											for _,data in ipairs(cache) do
+												if data.f then
+													item.f = data.f;
+												end
+												if data.g and #data.g > 0 then
+													if not item.g then
+														item.g = {};
+														item.progress = 0;
+														item.total = 0;
+														item.OnUpdate = OnUpdateForItem;
 													end
-													if data.g and #data.g > 0 then
-														if not item.g then
-															item.g = {};
-															item.progress = 0;
-															item.total = 0;
-															item.OnUpdate = OnUpdateForItem;
-														end
-														MergeObjects(item.g, data.g);
-													end
+													MergeObjects(item.g, data.g);
 												end
 											end
 											if not item.g then
@@ -13146,9 +13159,9 @@ app:GetWindow("WorldQuests", UIParent, function(self)
 												item.OnUpdate = OnUpdateForItem;
 											end
 											MergeObject(questObject.g, item);
-										else
-											return true;
 										end
+									else
+										retry = true;
 									end
 								end
 							end
@@ -13335,6 +13348,27 @@ app:GetWindow("WorldQuests", UIParent, function(self)
 					end
 					table.insert(temp, groupFinder);
 				end
+				
+				if retry == true
+				then
+					-- print("Missing API quest data on this World Quest refresh");
+					return true;
+				end
+				
+				-- Put a 'Clear World Quests' click at the bottom
+				MergeObject(temp, {
+						['text'] = "Clear World Quests",
+						['icon'] = "Interface\\Icons\\ability_racial_haymaker",
+						['description'] = "Click to clear the current information within the World Quests frame",
+						['hash'] = "funClearWorldQuests",
+						['OnClick'] = function(data, button)
+							Push(self, "WorldQuests-Clear", self.Clear);
+							return true;
+						end,
+						['OnUpdate'] = function(data) 
+							data.visible = true;
+						end,
+					});
 				
 				for i,o in ipairs(temp) do
 					UnsetNotCollectible(o);


### PR DESCRIPTION
I did some debugging to try and find why the **/attwq** window lags so horribly during active faction invasions and made some tweaks to the logic as a result. _Also in main.lua, value2 was spelled valu2 so that would probably explode if it even was actually called, but it seems to be in a place where an error() would be thrown regardless and I couldn't think of anywhere it would actually be utilized._

It looks like the Rebuild() method is thrown onto the Stack for processing, but anytime an API call to retrieve the itemID or currencyID for a given existing world quest reward returned _nil_, the entire function would simply return true, causing the Stack to re-evaluate the entire method on the next pass of OnUpdate. This would then cause the iterative, stuttering of the entire game while the Rebuild() method was repeatedly looped until every bit of API data became called & cached in the Client and returned actual values. Each pass of the method would end up calling a new API call which had not yet been cached, leading to only one new piece of API data being collected by the Rebuild() on each run, thus leading to many loops of the gigantic function before it finally would complete.

Instead of returning immediately, a 'retry' variable (which existed but was previously unused) could be utilized instead to track whether missing API data was presumed to have been encountered, and whether to retry the Rebuild. In this way, every necessary API call would be called prior to the Rebuild() method starting over if necessary and as such the API data becomes cached in the Client all at once on a repeated pass of Rebuild().

For some reason, we still have to click the 'Update Now' button multiple times as some API data is inevitably missing after the first/second pass of Rebuild(), but we don't _know_ that for sure when inside the method. The WoW API is certainly weird in some cases...

I also added a button for clicking to clear all the data in the /attwq window. Currently, if you put on the setting "Treat Currencies as containers" and refresh the world quests, then disable that setting and refresh, you cannot get rid of the currencies from the window until you reload the UI. Same with if you happen to be logged in on one character for many hours, old world quests will persist in the list even after they've expired. So having a button to simply clear all the data and pull from scratch seems like a nice feature.

I feel like the functionality within the Rebuild() method could benefit greatly from being redesigned using the existing 'coroutine' functionality. In this way, each of the portions of the method (Emissary, Invasions, World Quests, Heroic Deeds, Group Finder, etc.) could be split into their own coroutines, and they could yield-process until the necessary API data was fully retrieved, thereby allowing much smoother Client framerate while the data was being retrieved in pieces into the Window, as well as providing iterative visual updates in the Client ("Waiting on API data...", "Refresh Complete", etc.). I don't have enough experience quite yet with LUA to know whether this is even possible or whether multiple methods on the Stack can update the same window object without any erroneous interactions. Though it appears to be completely single-threaded processing, so I would expect it to be fine. But before trying to figure any of that out, it would be nice to know whether that would be a desired feature development, or whether there were other plans for the /attwq functionality.

Thanks