### PR TITLE
Fixed 'Track Repeatable Quests'

### DIFF
--- a/AllTheThings.lua
+++ b/AllTheThings.lua
@@ -6444,7 +6444,7 @@ app.BaseQuest = {
 		elseif key == "trackable" then
 			return true;
 		elseif key == "collectible" then
-			return app.CollectibleQuests and ((not t.isBreadcrumb and not t.DisablePartySync) or app.AccountWideQuests) and (not t.repeatable or app.Settings:GetTooltipSetting("Repeatable")) and ((not t.isWorldQuest and not t.repeatable) or app.Settings:GetTooltipSetting("RepeatableFirstTime"));
+			return app.CollectibleQuests and ((not t.isBreadcrumb and not t.DisablePartySync) or app.AccountWideQuests) and (not t.repeatable or app.Settings:GetTooltipSetting("Repeatable"));
 		elseif key == "repeatable" then
 			return t.isDaily or t.isWeekly or t.isMonthly or t.isYearly or t.isWorldQuest;
 		elseif key == "saved" or key == "collected" then


### PR DESCRIPTION
Some logic in the Quest lib was only treating repeatable Quests as collectible if the '**Only First Time**' setting was _additionally_ toggled with the '**Track Repeatable Things**' setting being enabled. This shouldn't be the case since the '**Only First Time**' setting is already functioning correctly to provide the _completion status_ of a Quest when it is treated as collectible and has been completed at least once.