### PR TITLE
Modified Recursive Expand/Collapse Logic

### DIFF
--- a/AllTheThings.lua
+++ b/AllTheThings.lua
@@ -1516,6 +1516,18 @@ local function ExpandGroupsRecursively(group, expanded, manual)
 		end
 	end
 end
+-- Returns true if any subgroup of the provided group is currently expanded, otherwise nil
+local function HasExpandedSubgroup(group)
+	if group and group.g then
+		for i, subgroup in ipairs(group.g) do
+			-- dont need recursion since a group has to be expanded for a subgroup to be visible within it
+			if subgroup.expanded then
+				return true;
+			end			
+		end
+	end
+	return false;
+end
 local function ReapplyExpand(g, g2)
 	for j,p in ipairs(g2) do
 		local found = false;
@@ -9022,11 +9034,8 @@ local function RowOnClick(self, button)
 				
 				-- If this reference is anything else, expand the groups.
 				if reference.g then
-					if self.index < 1 and #reference.g > 0 then
-						ExpandGroupsRecursively(reference, not reference.g[1].expanded, true);
-					else
-						ExpandGroupsRecursively(reference, not reference.expanded, true);
-					end
+					-- always expand if collapsed or if clicked the header and all immediate subgroups are collapsed, otherwise collapse
+					ExpandGroupsRecursively(reference, not reference.expanded or (self.index < 1 and not HasExpandedSubgroup(reference)), true);
 					self:GetParent():GetParent():Update();
 					return true;
 				end


### PR DESCRIPTION
Currently, the recursive expand/collapse logic is based on the **first** subgroup when clicking the header group of a window. This leads to the World Quests window (or any other window with a non-expandable first group row) being unable to be recursively collapsed by clicking the header row. Additionally, if the first subgroup was not expanded, but any other subgroups within the window were expanded, clicking the header group would simply expand all subgroups, requiring an additional click to collapse all subgroups.

This proposed change alters the logic slightly to perform a check across all immediate subgroups when clicking a header group to find **any** expanded group to determine if collapsing should be performed instead of expanding. This allows for the World Quests window to now be collapsible like any other window.

The new caveat introduced by this logic change is that **visible, 100% collected groups containing no visible subgroups can be expanded (changing nothing visually to the User) and make it appear as if a recursive expand had no effect when clicked the first time**. Upon a second click, the recursive expand works as expected (since the 100% completed 'expanded' group would have been 'collapsed' on the first click). It seems this would be a very small use case since the User would need to have the "Show Completed Groups" setting enabled, along with manually attempting to expand ONLY a completed group with no subgroups (such as Flight Paths).