### PR TITLE
Fixed Breadcrumb Visibility

### DIFF
--- a/.contrib/Parser/DATAS/02 - Outdoor Zones/11 Zandalar/02 Nazmir/Quests.lua
+++ b/.contrib/Parser/DATAS/02 - Outdoor Zones/11 Zandalar/02 Nazmir/Quests.lua
@@ -469,7 +469,7 @@ _.Zones =
 				
 				q(48492, {	-- Getting a Leg Up
 					["sourceQuests"] = { 49477 },	-- Surprise Backup
-					["provider"] = { "n", 126346 },	-- Chadwick Paxton
+					["provider"] = { "n", 126289 },	-- Chadwick Paxton (with no legs)
 					["coord"] = { 28.6, 43.8, 863 },
 					["races"] = HORDE_ONLY,
 				}),

--- a/AllTheThings.lua
+++ b/AllTheThings.lua
@@ -7954,7 +7954,7 @@ UpdateGroup = function(parent, group)
 					-- If this group is trackable, then we should show it.
 					if app.ShowIncompleteThings(group) then
 						group.visible = not group.saved;
-						if group.visible then
+						if group.visible and not parent.visible then
 							-- Ensure that the parent does not hide a visible, incomplete thing (switched from 1 to true in group filtering so as to not overwrite based on the group filtering)
 							parent.visible = 1;
 						end

--- a/AllTheThings.lua
+++ b/AllTheThings.lua
@@ -7954,7 +7954,7 @@ UpdateGroup = function(parent, group)
 					-- If this group is trackable, then we should show it.
 					if app.ShowIncompleteThings(group) then
 						group.visible = not group.saved;
-						if group.visible and not parent.visible then
+						if group.visible then
 							-- Ensure that the parent does not hide a visible, incomplete thing (switched from 1 to true in group filtering so as to not overwrite based on the group filtering)
 							parent.visible = 1;
 						end

--- a/AllTheThings.lua
+++ b/AllTheThings.lua
@@ -7953,8 +7953,8 @@ UpdateGroup = function(parent, group)
 				elseif group.trackable then
 					-- If this group is trackable, then we should show it.
 					if app.ShowIncompleteThings(group) then
-						if not group.saved then
-							group.visible = true;
+						group.visible = not group.saved;
+						if group.visible then
 							-- Ensure that the parent does not hide a visible, incomplete thing (switched from 1 to true in group filtering so as to not overwrite based on the group filtering)
 							parent.visible = 1;
 						end

--- a/Settings.lua
+++ b/Settings.lua
@@ -561,7 +561,7 @@ settings.UpdateMode = function(self)
 	else
 		app.CollectedItemVisibilityFilter = app.Filter;
 	end
-	if self:Get("Show:IncompleteThings") then
+	if self:Get("Show:IncompleteThings") or self:Get("DebugMode") then
 		app.ShowIncompleteThings = app.FilterItemTrackable;
 	else
 		app.ShowIncompleteThings = app.Filter;
@@ -588,7 +588,7 @@ settings.UpdateMode = function(self)
 		app.RequireBindingFilter = app.NoFilter;
 	end
 	app:UnregisterEvent("PLAYER_LEVEL_UP");
-	if self:Get("Filter:ByLevel") then
+	if self:Get("Filter:ByLevel") or self:Get("DebugMode") then
 		app:RegisterEvent("PLAYER_LEVEL_UP");
 		app.GroupRequirementsFilter = app.FilterGroupsByLevel;
 	else

--- a/Settings.lua
+++ b/Settings.lua
@@ -464,6 +464,7 @@ settings.UpdateMode = function(self)
 		app.SeasonalItemFilter = app.NoFilter;
 		app.UnobtainableItemFilter = app.NoFilter;
 		app.VisibilityFilter = app.NoFilter;
+		app.ShowIncompleteThings = app.NoFilter;
 		
 		app.AccountWideAchievements = true;
 		app.AccountWideBattlePets = true;
@@ -507,6 +508,11 @@ settings.UpdateMode = function(self)
 			app.UnobtainableItemFilter = app.FilterItemClass_UnobtainableItem;
 		else
 			app.UnobtainableItemFilter = app.NoFilter;
+		end
+		if self:Get("Show:IncompleteThings") then
+			app.ShowIncompleteThings = app.FilterItemTrackable;
+		else
+			app.ShowIncompleteThings = app.Filter;
 		end
 		
 		app.AccountWideAchievements = self:Get("AccountWide:Achievements");
@@ -561,11 +567,6 @@ settings.UpdateMode = function(self)
 	else
 		app.CollectedItemVisibilityFilter = app.Filter;
 	end
-	if self:Get("Show:IncompleteThings") or self:Get("DebugMode") then
-		app.ShowIncompleteThings = app.FilterItemTrackable;
-	else
-		app.ShowIncompleteThings = app.Filter;
-	end
 	if self:Get("AccountWide:Achievements") then
 		app.AchievementFilter = 4;
 	else
@@ -575,8 +576,7 @@ settings.UpdateMode = function(self)
 		app.RecipeChecker = app.GetDataSubMember;
 	else
 		app.RecipeChecker = app.GetTempDataSubMember;
-	end
-	
+	end	
 	if self:Get("Filter:BoEs") then
 		app.ItemBindFilter = app.FilterItemBind;
 	else
@@ -588,7 +588,7 @@ settings.UpdateMode = function(self)
 		app.RequireBindingFilter = app.NoFilter;
 	end
 	app:UnregisterEvent("PLAYER_LEVEL_UP");
-	if self:Get("Filter:ByLevel") or self:Get("DebugMode") then
+	if self:Get("Filter:ByLevel") and not self:Get("DebugMode") then
 		app:RegisterEvent("PLAYER_LEVEL_UP");
 		app.GroupRequirementsFilter = app.FilterGroupsByLevel;
 	else

--- a/Settings.lua
+++ b/Settings.lua
@@ -1385,7 +1385,7 @@ function(self)
 	settings:UpdateMode();
 	app:RefreshData();
 end);
-ShowCollectedThingsCheckBox:SetATTTooltip("Enable this option if you want to see completed groups as a header with a completion percentage. If a group has nothing relevant for your class, this setting will also make those groups appear in the listing.\n\nWe recommend you turn this setting off as it will conserve the space in the mini list and allow you to quickly see what you are missing from the zone.");
+ShowCollectedThingsCheckBox:SetATTTooltip("Enable this option to see Things which have already been Collected.\n\nWe recommend you turn this setting off as it will conserve the space in the mini list and allow you to quickly see what you are missing from the zone.");
 ShowCollectedThingsCheckBox:SetPoint("TOPLEFT", ShowCompletedGroupsCheckBox, "BOTTOMLEFT", 0, 4);
 
 local ShowIncompleteThingsCheckBox = settings:CreateCheckBox("Show Incomplete Things",


### PR DESCRIPTION
Fixed when completing a Breadcrumb that it removes from the Minilist (Prime list continues to require forced Refresh due to performance concerns)

Also **Debug Mode** now ignores **Filter Things By Level** and does not require **Show Incomplete Things** to include Non-Collectible, Incomplete Things in a list (though technically, most things become treated as 'Collectible' in Debug mode anyway, but for consistency sake)

_Things Noticed During Testing_:
- Heirlooms/Artifacts have some 'delayed' information which can change the Debug totals the first few times Debug is toggled. Will have to investigate whether that is able to be remediated. I think it's known that Artifact tracking is definitely not accurate right now anyway...
- Character-specific Completed Breadcrumbs are only visible in a list with **Account-Wide Quests** or **Debug Mode**. Should **Show Collected Things** also include 'Completed Non-Collectible' Things when not tracking Account Wide?