### PR TITLE
Warfront Clean Up

### DIFF
--- a/.contrib/Parser/DATAS/02 - Outdoor Zones/01 Kalimdor/Darkshore/0 - Metadata.lua
+++ b/.contrib/Parser/DATAS/02 - Outdoor Zones/01 Kalimdor/Darkshore/0 - Metadata.lua
@@ -7,7 +7,6 @@ _.Zones =
 		m(62, {	-- Darkshore
 			["achievementID"] = 844,
 			["description"] = "|cff66ccffDarkshore, a shadowy forest punctuated by waterfalls, is one of the saddest zones in the game. It underwent many changes and heavy losses in the Cataclysm--invasions by the trolls, Twilight Cultist infiltrations in the south, and most notably, the destruction of Auberdine, viewed by many as one of the most atmospheric towns. Alliance players help rescue and comfort dying NPCs, aid the refugees of Auberdine, and assist Malfurion Stormrage in driving back the threat of the cultists.|r",				
-			["maps"] = { 1332 },	-- Battle of Darkshore (Warfront)
 			["lvl"] = 10,
 		}),
 	}),

--- a/.contrib/Parser/DATAS/02 - Outdoor Zones/10 Kul Tiras/01 Boralus/War Effort.lua
+++ b/.contrib/Parser/DATAS/02 - Outdoor Zones/10 Kul Tiras/01 Boralus/War Effort.lua
@@ -8,9 +8,7 @@ _.Zones =
 		m(1161, {	-- Boralus
 			n(-10057, {	-- War Effort
 				["lvl"] = 120,
-				["achievementID"] = 12874,	-- An Eventful Battle
 				["races"] = ALLIANCE_ONLY,
-				["description"] = "|cff66ccffLocated in the Arathi Highlands, Stromgarde is one of the key locations in the struggle for control of the Eastern Kingdoms. For the Alliance, Stromgarde sits in a critical defensive position. Following the battle for Lordaeron, the Horde threat still looms over the continent, and holding Stromgarde will be key if you hope to keep the Horde's aggression at bay.\n\nFor the Horde, securing Stromgarde would set the stage for an assault on the heart of the Eastern Kingdoms and serve as a launching point for a campaign against the worgen of the kingdom of Gilneas. This location is also key in the defense of the blood elven capital, Silvermoon City, in the north.|r",
 				["g"] = {
 					n(QUESTS, {
 						q(53195, {	-- Arathi Donations: Akunda's Bite

--- a/.contrib/Parser/DATAS/02 - Outdoor Zones/11 Zandalar/01 Dazar'alor/War Effort.lua
+++ b/.contrib/Parser/DATAS/02 - Outdoor Zones/11 Zandalar/01 Dazar'alor/War Effort.lua
@@ -8,9 +8,7 @@ _.Zones =
 		m(1163, {	-- Dazar'alor
 			n(-10057, {	-- War Effort
 				["lvl"] = 120,
-				["achievementID"] = 12874,	-- An Eventful Battle
 				["races"] = HORDE_ONLY,
-				["description"] = "|cff66ccffLocated in the Arathi Highlands, Stromgarde is one of the key locations in the struggle for control of the Eastern Kingdoms. For the Alliance, Stromgarde sits in a critical defensive position. Following the battle for Lordaeron, the Horde threat still looms over the continent, and holding Stromgarde will be key if you hope to keep the Horde's aggression at bay.\n\nFor the Horde, securing Stromgarde would set the stage for an assault on the heart of the Eastern Kingdoms and serve as a launching point for a campaign against the worgen of the kingdom of Gilneas. This location is also key in the defense of the blood elven capital, Silvermoon City, in the north.|r",
 				["g"] = {
 					n(QUESTS, {
 						q(52792, {	-- Arathi Donations: Akunda's Bite

--- a/.contrib/Parser/DATAS/06 - Expansion Features/07 War Effort/Arathi Highlands Warfront/0 - Metadata.lua
+++ b/.contrib/Parser/DATAS/06 - Expansion Features/07 War Effort/Arathi Highlands Warfront/0 - Metadata.lua
@@ -5,14 +5,15 @@
 _.ExpansionFeatures =
 {
 	n(-10057, {	-- War Effort
-		n(-233, {	-- War Front: The Battle for Stromgarde
+		n(-233, {	-- Warfront: The Battle for Stromgarde
 			["lvl"] = 120,
-			["achievementID"] = 12874,	-- An Eventful Battle
 			["description"] = "|cff66ccffLocated in the Arathi Highlands, Stromgarde is one of the key locations in the struggle for controlling of the Eastern Kingdoms. For the Alliance, Stromgarde sits in a critical defensive position. Following the battle for Lordaeron, the Horde threat still looms over the continent and holding Stromgarde will be key if you hope to keep the Horde's aggression at bay.\n\nFor the Horde, securing Stromgarde would set the stage for an assault on the heart of the Eastern Kingdoms and serve as a launching point for a campaign against the worgen of the kingdom of Gilneas. This location is also key in the defense of the blood elven capital, Silvermoon City, in the north.|r", 
 			["maps"] = {
-				1044,
-				943,	-- Actual Scenario [Horde]
-				906,
+				906, -- ???
+				943, -- Actual Scenario [Horde]
+				1044, -- Actual Scenario [Alliance]
+				-- 1158, -- ???
+				-- 1244, -- ???
 			},
 			["crs"] = {
 				140552,	-- War Table (Alliance)

--- a/.contrib/Parser/DATAS/06 - Expansion Features/07 War Effort/Arathi Highlands/0 - Metadata.lua
+++ b/.contrib/Parser/DATAS/06 - Expansion Features/07 War Effort/Arathi Highlands/0 - Metadata.lua
@@ -7,7 +7,6 @@ _.ExpansionFeatures =
 		{	-- Arathi Highlands
 			["mapID"] = 14,	-- Arathi Highlands
 			["lvl"] = 120,
-			["achievementID"] = 12874,	-- An Eventful Battle
 			["description"] = "|cff66ccffLocated in the Arathi Highlands, Stromgarde is one of the key locations in the struggle for controlling of the Eastern Kingdoms. For the Alliance, Stromgarde sits in a critical defensive position. Following the battle for Lordaeron, the Horde threat still looms over the continent and holding Stromgarde will be key if you hope to keep the Horde's aggression at bay.\n\nFor the Horde, securing Stromgarde would set the stage for an assault on the heart of the Eastern Kingdoms and serve as a launching point for a campaign against the worgen of the kingdom of Gilneas. This location is also key in the defense of the blood elven capital, Silvermoon City, in the north.|r", 
 		},
 	}),

--- a/.contrib/Parser/DATAS/06 - Expansion Features/07 War Effort/Darkshore Warfront/0 - Metadata.lua
+++ b/.contrib/Parser/DATAS/06 - Expansion Features/07 War Effort/Darkshore Warfront/0 - Metadata.lua
@@ -1,0 +1,23 @@
+---------------------------------------------------
+--          Z O N E S        M O D U L E         --
+---------------------------------------------------
+
+_.ExpansionFeatures =
+{
+	n(-10057, {	-- War Effort
+		n(-237, {	-- Warfront: The Battle for Darkshore
+			["lvl"] = 120,
+			["description"] = "|cff66ccffThe Battle for Darkshore is the second warfront in Battle for Azeroth where the Forsaken and the Night Elves struggle for control of a staging area near the former Night Elven capital region of Teldrassil.|r", 
+			["maps"] = {
+				-- 1203,	-- ???
+				-- 1309,	-- 8.2+ Darkshore ?
+				1338,	-- Actual Scenario [Alliance]
+				1332,	-- Actual Scenario [Horde]
+			},
+			["crs"] = {
+				140552,	-- War Table (Alliance)
+				131752,	-- War Table (Horde)
+			},
+		}),
+	}),
+};

--- a/.contrib/Parser/DATAS/06 - Expansion Features/07 War Effort/Darkshore/0 - Metadata.lua
+++ b/.contrib/Parser/DATAS/06 - Expansion Features/07 War Effort/Darkshore/0 - Metadata.lua
@@ -1,0 +1,16 @@
+---------------------------------------------------
+--          Z O N E S        M O D U L E         --
+---------------------------------------------------
+_.ExpansionFeatures =
+{
+	n(-10057, {	-- War Effort
+		{	-- Darkshore
+			["mapID"] = 62,	-- Darkshore
+			["lvl"] = 120,
+			["description"] = "|cff66ccffThe Battle for Darkshore is the second warfront in Battle for Azeroth where the Forsaken and the Night Elves struggle for control of a staging area near the former Night Elven capital region of Teldrassil.|r", 
+			["maps"] = {
+				1333,	-- Horde Intro Quest Map
+			},
+		},
+	}),
+};

--- a/.contrib/Parser/DATAS/06 - Expansion Features/07 War Effort/Darkshore/Rares.lua
+++ b/.contrib/Parser/DATAS/06 - Expansion Features/07 War Effort/Darkshore/Rares.lua
@@ -5,12 +5,6 @@ _.ExpansionFeatures =
 {
 	n(-10057, {	-- War Effort
 		m(62, {	-- Darkshore
-			["lvl"] = 120,
-			["maps"] = {
-				1333,	-- Horde Intro Quest Map
-			},
-			["achievementID"] = 13296,	-- War for the Shore
-			["description"] = "|cff66ccffThe Battle for Darkshore is the second warfront in Battle for Azeroth where the Forsaken and the night elves struggle for control of a staging area near the former night elven capital region of Teldrassil.|r", 
 			["g"] = {
 				n(RARES, {
 					["g"] = {


### PR DESCRIPTION
Fixed up some Warfront stuff to be consistent with the common database design.

Moved common information into proper metadata files for Darkshore warfront and 'new' Darkshore.

Removed random achievement tagging of some of the Warfront headers... it really doesn't make sense to tag non-collectible headers with achievement tooltips, especially when the header contains content completely unrelated to the achievement. Plus it makes the header itself show a 'Contains' based on the Achievement rather than the actual content of the header.

Also added the proper Darkshore Warfront MapID's to new metadata files so _hopefully_ this will finally work properly in ATT.

This should fix #518 for both Horde and Alliance players. Will have to verify for certain when it becomes available again for both factions.