### PR TITLE
Fixed Tooltip Interaction with ArkInventory

### DIFF
--- a/AllTheThings.lua
+++ b/AllTheThings.lua
@@ -4178,6 +4178,7 @@ end
 local function AttachTooltip(self)
 	if not self.AllTheThingsProcessing then
 		self.AllTheThingsProcessing = true;
+		self.UpdateTooltip = function(self) return true; end
 		if (not InCombatLockdown() or app.Settings:GetTooltipSetting("DisplayInCombat")) and app.Settings:GetTooltipSetting("Enabled") then
 			local numLines = self:NumLines();
 			if numLines > 0 then
@@ -4357,6 +4358,7 @@ local function AttachBattlePetTooltip(self, data, quantity, detail)
 end
 local function ClearTooltip(self)
 	self.AllTheThingsProcessing = nil;
+	self.UpdateTooltip = nil;
 end
 
 -- Tooltip Hooks

--- a/AllTheThings.lua
+++ b/AllTheThings.lua
@@ -4178,7 +4178,7 @@ end
 local function AttachTooltip(self)
 	if not self.AllTheThingsProcessing then
 		self.AllTheThingsProcessing = true;
-		self.UpdateTooltip = function(self) return true; end
+		self.UpdateTooltip = function(self) return; end
 		if (not InCombatLockdown() or app.Settings:GetTooltipSetting("DisplayInCombat")) and app.Settings:GetTooltipSetting("Enabled") then
 			local numLines = self:NumLines();
 			if numLines > 0 then


### PR DESCRIPTION
Since people complain both directions that "It isn't my fault" I decided to look at the code for both addons and make the simplest fix I could which achieves the following:
* Not removing information provided by either addon
* Not re-structuring the way tooltips are built from ATT
* Not looking for external data from one addon to the other to perform logic to fix the issue

Basically, using **UpdateTooltip** allows the game itself to refresh the tooltip as needed, and ArkInventory's code will ignore refreshing tooltips where the GameTooltip frame has this defined, or the Owner of said GameTooltip has this defined.