### PR TITLE
Update coords for Cataclysm vendors in Stormwind

### DIFF
--- a/.contrib/Parser/DATAS/02 - Outdoor Zones/02 Eastern Kingdoms/1 - Stormwind City/Vendors.lua
+++ b/.contrib/Parser/DATAS/02 - Outdoor Zones/02 Eastern Kingdoms/1 - Stormwind City/Vendors.lua
@@ -2946,7 +2946,7 @@ _.Zones =
 					},
 				}),
 				n(44246, {	-- Magatha Silverton
-					["coord"] = { 79.0, 69.6, 84 },
+					["coord"] = { 75.5, 66.1, 84 },
 					["races"] = ALLIANCE_ONLY,
 					["g"] = {
 						i(71213),	-- Amulet of Burning Brilliance
@@ -4399,7 +4399,7 @@ _.Zones =
 					},
 				}),
 				n(58154, {	-- Toren Landow
-					["coord"] = { 79.0, 70.1, 84 },
+					["coord"] = { 75.7, 65.9, 84 },
 					["races"] = ALLIANCE_ONLY,
 					["g"] = {
 						i(57931),	-- Amulet of Dull Dreaming


### PR DESCRIPTION
The vendors in Orgrimmar stayed where they were, but the Stormwind ones moved. (See [wowhead comments](https://www.wowhead.com/npc=44246/magatha-silverton#comments:id=3238797)).

[Faldren Tillsdale the "Valor Quartermaster"](https://www.wowhead.com/npc=44245/faldren-tillsdale#comments) is currently MIA.