### PR TITLE
Hellfire Peninsula quests removed in 9.0

### DIFF
--- a/.contrib/Parser/DATAS/02 - Outdoor Zones/03 Outland/Hellfire Peninsula.lua
+++ b/.contrib/Parser/DATAS/02 - Outdoor Zones/03 Outland/Hellfire Peninsula.lua
@@ -2557,14 +2557,14 @@ root("Zones", {
 					}),
 					q(49862, {	-- To Outland! [Alliance]
 						["description"] = "Breadcrumb quest when you first step in Outland. You will not be able to get it if you visited Outland before this quest was implemented.",
-						["timeline"] = { "added 7.3.5.25600" },
+						["timeline"] = { "added 7.3.5.25600", "removed 9.0" },
 						["races"] = ALLIANCE_ONLY,
 						["isBreadcrumb"] = true,
 						["lvl"] = lvlsquish(58, 10, 58),
 					}),
 					q(49816, {	-- To Outland! [Horde]
 						["description"] = "Breadcrumb quest when you first step in Outland. You will not be able to get it if you visited Outland before this quest was implemented.",
-						["timeline"] = { "added 7.3.5.25600" },
+						["timeline"] = { "added 7.3.5.25600", "removed 9.0" },
 						["races"] = HORDE_ONLY,
 						["isBreadcrumb"] = true,
 						["lvl"] = lvlsquish(58, 10, 58),


### PR DESCRIPTION
As reported by Shoogen: https://us.forums.blizzard.com/en/blizzard/en/blizzard/t/incorrect-and-incomplete-data-in-wow-quest-apis/11112/3