### PR TITLE
Use correct cost for fierce scarabid

### DIFF
--- a/.contrib/Parser/DATAS/02 - Outdoor Zones/13 Shadowlands/Zereth Mortis/Protoform Synthesis.lua
+++ b/.contrib/Parser/DATAS/02 - Outdoor Zones/13 Shadowlands/Zereth Mortis/Protoform Synthesis.lua
@@ -603,7 +603,7 @@ root("Zones", m(SHADOWLANDS, bubbleDown({ ["timeline"] = { "added 9.2.0" } }, {
 					}),
 					i(189365, {	-- Fierce Scarabid
 						["cost"] = {
-							{ "i", GENESIS, 300 },
+							{ "i", GENESIS, 400 },
 							{ "i", SCARABID_LATTICE, 1},
 							{ "i", 189163, 1 },	-- 1x Glimmer of Motion
 						},


### PR DESCRIPTION
The fierce scarabid costs 400 Genesis Mote, as can be seen ingame and here: https://www.wowhead.com/spell=364665/fierce-scarabid