### PR TITLE
Quest Population Updates

### DIFF
--- a/AllTheThings.lua
+++ b/AllTheThings.lua
@@ -8250,8 +8250,8 @@ local function RefreshQuestCompletionState(questID)
 	end
 
 	-- update if any quests were even completed to ensure visible changes occur
-	if DirtyQuests.DIRTY then
-		local updateQuests = {};
+	if questID or DirtyQuests.DIRTY then
+		local updateQuests = { questID };
 		for questID,_ in pairs(DirtyQuests) do
 			tinsert(updateQuests, questID);
 			-- Certain quests being completed should trigger a refresh of the Custom Collect status of the character (i.e. Covenant Switches, Threads of Fate, etc.)
@@ -14970,18 +14970,6 @@ function app:CreateMiniListForGroup(group)
 				app.CollectibleQuests = oldQuestCollection;
 				app.AccountWideQuests = oldQuestAccountWide;
 			end;
-			popout:SetScript("OnEvent", function(self, e, ...)
-				-- print("EVENT", e, ...)
-				if self:IsVisible() then
-					-- print("QUEST_LOG_UPDATE:questChainWindow")
-					self:Update(true);
-				end
-			end);
-			-- Register Events which should cause an update to the Quest popout
-			self:RegisterEvent("QUEST_LOG_UPDATE");
-			self:RegisterEvent("QUEST_TURNED_IN");
-			self:RegisterEvent("QUEST_ACCEPTED");
-			self:RegisterEvent("QUEST_REMOVED");
 			-- Populate the Quest Rewards
 			app.TryPopulateQuestRewards(group)
 		end
@@ -23273,6 +23261,7 @@ app.events.CRITERIA_UPDATE = function(...)
 	-- print("CRITERIA_UPDATE",...)
 	-- sometimes triggers many times at once but refresh quest info is a 1 sec callback threshold
 	app.RefreshQuestInfo();
+	app:RefreshWindows();
 end
 app.events.QUEST_TURNED_IN = function(questID)
 	-- print("QUEST_TURNED_IN")
@@ -23286,10 +23275,10 @@ end
 -- 	-- print("QUEST_FINISHED")
 -- 	app.RefreshQuestInfo();
 -- end
-app.events.QUEST_REMOVED = function()
-	-- print("QUEST_REMOVED")
-	-- simply soft update windows to remove any visible star markers
-	app:UpdateWindows();
+app.events.QUEST_REMOVED = function(questID)
+	-- app.PrintDebug("QUEST_REMOVED",questID)
+	-- Make sure windows refresh incase any show the removed quest
+	app:RefreshWindows();
 end
 app.events.QUEST_ACCEPTED = function(questID)
 	-- print("QUEST_ACCEPTED",questID)
@@ -23313,8 +23302,8 @@ app.events.QUEST_ACCEPTED = function(questID)
 			-- Run this warning check after a small delay in case addons pick up quests before the turned in quest is registered as complete
 			DelayedCallback(app.CheckForBreadcrumbPrevention, 1, title, questID);
 		end
-		-- Make sure windows update incase any show the picked up quest
-		app:UpdateWindows();
+		-- Make sure windows refresh incase any show the picked up quest
+		app:RefreshWindows();
 	end
 end
 app.events.PET_BATTLE_OPENING_START = function(...)

--- a/AllTheThings.lua
+++ b/AllTheThings.lua
@@ -4735,7 +4735,6 @@ end
 (function()
 local included = {};
 local knownSkills;
-local DuplicatePreventionLevel = 5;
 -- ItemID's which should be skipped when filling purchases with certain levels of 'skippability'
 app.SkipPurchases = {
 	[-1] = 0,	-- Whether to skip certain cost items

--- a/AllTheThings.lua
+++ b/AllTheThings.lua
@@ -21148,12 +21148,10 @@ customWindowUpdates["WorldQuests"] = function(self, force, got)
 				end
 
 				-- put all the things into the window data, turning them into objects as well
-				-- NestObjects(self.data, temp, true);
 				NestObjects(self.data, temp);
 				-- Build the heirarchy
 				self:BuildData();
-				-- Force Update Callback
-				-- Callback(self.Update, self, true);
+				-- Force Update
 				self:Update(true);
 			end
 		end

--- a/AllTheThings.lua
+++ b/AllTheThings.lua
@@ -6059,7 +6059,7 @@ local function SearchForMissingItemNames(group)
 end
 -- Dynamically increments the progress for the parent heirarchy of each collectible search result
 local function UpdateSearchResults(searchResults)
-	app.PrintDebug("UpdateSearchResults",searchResults and #searchResults)
+	-- app.PrintDebug("UpdateSearchResults",searchResults and #searchResults)
 	if searchResults then
 		-- Update all the results within visible windows
 		local hashes = {};
@@ -6071,11 +6071,11 @@ local function UpdateSearchResults(searchResults)
 		end
 
 		-- loop through visible ATT windows and collect matching groups
-		app.PrintDebug("Checking Windows...")
+		-- app.PrintDebug("Checking Windows...")
 		for suffix,window in pairs(app.Windows) do
 			-- Collect matching groups from the updating groups from visible windows other than Main list
 			if window.Suffix ~= "Prime" and window:IsVisible() then
-				app.PrintDebug(window.Suffix)
+				-- app.PrintDebug(window.Suffix)
 				for _,result in ipairs(searchResults) do
 					SearchForSpecificGroups(found, window.data, hashes);
 				end
@@ -6084,12 +6084,12 @@ local function UpdateSearchResults(searchResults)
 
 		-- apply direct updates to all found groups
 		local Update = app.DirectGroupUpdate;
-		app.PrintDebug("Updating",#found,"groups")
+		-- app.PrintDebug("Updating",#found,"groups")
 		for _,o in ipairs(found) do
 			Update(o);
 		end
 	end
-	app.PrintDebug("UpdateSearchResults Done")
+	-- app.PrintDebug("UpdateSearchResults Done")
 end
 -- Pulls the field search results for the rawID's and passes the results into UpdateSearchResults
 local function UpdateRawIDs(field, ids)
@@ -16553,7 +16553,7 @@ local function UpdateWindow(self, force, got)
 				-- app.PrintDebug("UpdateGroups",self.Suffix)
 				TopLevelUpdateGroup(self.data, self);
 				self.HasPendingUpdate = nil;
-				-- app.PrintDebug("Done")
+				-- app.PrintDebugPrior("Done")
 			end
 
 			-- Should the groups in this window be expanded prior to processing the rows for display
@@ -16596,6 +16596,7 @@ local function UpdateWindow(self, force, got)
 			end
 
 			self:Refresh();
+			-- app.PrintDebugPrior("Update:Done")
 			return true;
 		else
 			local expireTime = self.ExpireTime;
@@ -16605,7 +16606,7 @@ local function UpdateWindow(self, force, got)
 				app.Windows[self.Suffix] = nil;
 			end
 		end
-		-- app.PrintDebug("Update:Done")
+		-- app.PrintDebugPrior("Update:None")
 	end
 end
 -- Allows a Window to set the root data object to itself and link the Window to the root data, if data exists

--- a/AllTheThings.lua
+++ b/AllTheThings.lua
@@ -16811,7 +16811,6 @@ function app:GetDataCache()
 		return group;
 	end
 	-- Update the Row Data by filtering raw data (this function only runs once)
-	local primeWindow = app:GetWindow("Prime");
 	local allData = setmetatable({}, { __index = function(t, key)
 			if key == "title" then
 				return t.mb_title1..DESCRIPTION_SEPARATOR..t.mb_title2;
@@ -16820,7 +16819,6 @@ function app:GetDataCache()
 			if key == "mb_title2" then return t.total == 0 and L["MAIN_LIST_REQUIRES_REFRESH"] or app.GetNumberOfItemsUntilNextPercentage(t.progress, t.total); end
 		end
 	});
-	primeWindow:SetData(allData);
 	allData.expanded = true;
 	allData.icon = app.asset("content");
 	allData.texcoord = {429 / 512, (429 + 36) / 512, 217 / 256, (217 + 36) / 256};
@@ -17323,8 +17321,9 @@ function app:GetDataCache()
 
 	-- The Main Window's Data
 	app.refreshDataForce = true;
-	BuildGroups(allData, allData.g);
-	app:GetWindow("Prime").data = allData;
+	local primeWindow = app:GetWindow("Prime");
+	primeWindow:SetData(allData);
+	primeWindow:BuildData();
 	CacheFields(allData);
 
 	-- Now build the hidden "Unsorted" Window's Data
@@ -17434,9 +17433,11 @@ function app:GetDataCache()
 		CacheFields(db);
 		app.ToggleCacheMaps();
 	end
-	BuildGroups(allData, allData.g);
-	app:GetWindow("Unsorted").data = allData;
+	local unsorted = app:GetWindow("Unsorted");
+	unsorted:SetData(allData);
+	unsorted:BuildData();
 
+	--[[
 	local buildCategoryEntry = function(self, headers, searchResults, inst)
 		local header = self;
 		for j,o in ipairs(searchResults) do
@@ -17571,6 +17572,7 @@ function app:GetDataCache()
 		tinsert(inst.parent.g, inst);
 		return inst;
 	end
+	-- ]]
 
 	-- Update Achievement data.
 	--[[

--- a/AllTheThings.lua
+++ b/AllTheThings.lua
@@ -14145,8 +14145,8 @@ local function DirectGroupUpdate(group)
 	-- After completing the Direct Update, setup a soft-update on the affected Window, if any
 	local window = app.RecursiveFirstParentWithField(group, "window");
 	if window then
-		-- app.PrintDebug("DGU:Callback Update",window.Suffix)
-		DelayedCallback(window.Update, 0.5, window);
+		-- app.PrintDebug("DGU:Callback Update",window.Suffix,window.isQuestChain)
+		DelayedCallback(window.Update, 0.5, window, window.isQuestChain);
 	end
 end
 app.DirectGroupUpdate = DirectGroupUpdate;

--- a/AllTheThings.lua
+++ b/AllTheThings.lua
@@ -4468,8 +4468,6 @@ local function GetCachedSearchResults(search, method, paramA, paramB, ...)
 
 		-- Resolve Cost, but not if the search itself was skipped (Mark of Honor)
 		if method ~= app.EmptyFunction then
-			-- Append currency info to any orphan currency groups
-			app.BuildCurrencies(group);
 			-- Fill up the group
 			app.FillGroups(group);
 			-- Sort by the heirarchy of the group
@@ -5108,27 +5106,6 @@ app.BuildSourceParent = function(group)
 	end
 end
 end)();
--- check for orphaned currency groups and fill them with things purchased by that currency
-app.BuildCurrencies = function(group)
-	-- app.PrintDebug("BuildCurrencies",group.key,group[group.key])
-	if group and group.g and #group.g > 0 then
-		for i=1,#group.g do
-			local o = group.g[i];
-			if o then
-				-- this is an empty currency group
-				-- app.PrintDebug("check for currency",o.key,o[o.key])
-				if o.key and o.key == "currencyID" and (not o.g or #o.g == 0) then
-					-- app.PrintDebug("empty currency group",o.currencyID);
-					local currencyGroup = GetCachedSearchResults("currencyID:" .. tostring(o.currencyID), app.SearchForField, "currencyID", o.currencyID);
-					if currencyGroup then
-						-- app.PrintDebug("found currency",currencyGroup.currencyID,#currencyGroup.g);
-						group.g[i] = currencyGroup;
-					end
-				end
-			end
-		end
-	end
-end
 -- check if the group has a cost which includes the given parameters
 app.HasCost = function(group, idType, id)
 	if group.cost and type(group.cost) == "table" then

--- a/AllTheThings.lua
+++ b/AllTheThings.lua
@@ -8242,7 +8242,7 @@ local CustomCollectQuests = {
 	[65079] = 1,	-- Shadowlands - Covenant - Necrolord
 };
 local function RefreshQuestCompletionState(questID)
-	-- print("QuestRefresh",questID)
+	-- app.PrintDebug("RefreshQuestCompletionState",questID)
 	if questID then
 		CompletedQuests[questID] = true;
 	else
@@ -8265,6 +8265,7 @@ local function RefreshQuestCompletionState(questID)
 	app:RegisterEvent("CRITERIA_UPDATE");
 	wipe(DirtyQuests);
 	wipe(npcQuestsCache);
+	-- app.PrintDebugPrior("RefreshedQuestCompletionState")
 end
 app.RefreshQuestInfo = function(questID)
 	-- print("RefreshQuestInfo",questID)
@@ -15138,7 +15139,7 @@ local function SetRowData(self, row, data)
 end
 local function Refresh(self)
 	if not app.IsReady or not self:IsVisible() then return; end
-	-- print("Refresh:",self.Suffix)
+	-- app.PrintDebug("Refresh:",self.Suffix)
 	if self:GetHeight() > 64 then self.ScrollBar:Show(); else self.ScrollBar:Hide(); end
 	if self:GetHeight() < 40 then
 		self.CloseButton:Hide();
@@ -15239,6 +15240,7 @@ local function Refresh(self)
 		Callback(self.Update, self, true);
 		self.doUpdate = nil;
 	end
+	-- app.PrintDebugPrior("Refreshed:",self.Suffix)
 end
 local function IsSelfOrChild(self, focus)
 	-- This function helps validate that the focus is within the local hierarchy.

--- a/src/base.lua
+++ b/src/base.lua
@@ -12,6 +12,7 @@ app.asset = function(path)
 end
 -- Consolidated debug-only print with preceding precise timestamp
 app.PrintDebug = function(...)
+	app.DEBUG_PRINT_LAST = GetTimePreciseSec();
 	if app.DEBUG_PRINT then print(GetTimePreciseSec(),...) end
 end
 -- Consolidated debug-only print with precise duration since last successful print


### PR DESCRIPTION
Mainly a huge refactor to basic Quest API querying and reward population within the ATT World Quests window. This should be far more accurate and smooth for pulling in currently-available content into the window.

There is still the known "issue" that 'storylines' are delayed and not currently accounted for depending on what data has been fully loaded on the Client. Hopefully I'll find a way to incorporate those rewards as well similar to the other updates...