### PR TITLE
Fix Terror Jelly Genesis Mote amount

### DIFF
--- a/.contrib/Parser/DATAS/02 - Outdoor Zones/13 Shadowlands/Zereth Mortis/Protoform Synthesis.lua
+++ b/.contrib/Parser/DATAS/02 - Outdoor Zones/13 Shadowlands/Zereth Mortis/Protoform Synthesis.lua
@@ -666,7 +666,7 @@ root("Zones", m(SHADOWLANDS, bubbleDown({ ["timeline"] = { "added 9.2.0" } }, {
 					}),
 					i(189372, {	-- Terror Jelly
 						["cost"] = {
-							{ "i", GENESIS, 300 },
+							{ "i", GENESIS, 400 },
 							{ "i", AURELID_LATTICE, 1},
 							{ "i", 189165, 1 },	-- 1x Glimmer of Predation
 						},


### PR DESCRIPTION
The correct amount is 400 as can be seen in game and here: https://www.wowhead.com/spell=364695/terror-jelly