### PR TITLE
Fix quest giver for The Ata'mal Terrace

### DIFF
--- a/.contrib/Parser/DATAS/02 - Outdoor Zones/03 Outland/Shadowmoon Valley.lua
+++ b/.contrib/Parser/DATAS/02 - Outdoor Zones/03 Outland/Shadowmoon Valley.lua
@@ -1432,7 +1432,7 @@ root(ROOTS.Zones, {
 						["minReputation"] = { 932, NEUTRAL },	-- The Aldor, Neutral.
 					}),
 					q(10707, {	-- The Ata'mal Terrace
-						["qg"] = 21770,	-- Akama
+						["qg"] = 21700,	-- Akama
 						["sourceQuest"] = 10706,	-- A Mysterious Portent
 						["coord"] = { 58.1, 48.1, SHADOWMOON_VALLEY },
 					}),


### PR DESCRIPTION
Should be [Akama](https://www.wowhead.com/npc=21700/akama) and not [Researcher Tiorus](https://www.wowhead.com/npc=21770). See: https://www.wowhead.com/quest=10707