### PR TITLE
Urga: Removed Springy Arachnoweave from Engineering as it no longer exists in classic. Added a max level limit to the "Adventurer's Wanted: Blackrock Depths" quest. Removed AQ20 class books as they are no longer learnable or collectable.

### DIFF
--- a/.contrib/Parser/DATAS/01 - Dungeons Raids/01 - Classic/2.5 Ruins of Ahn'Qiraj.lua
+++ b/.contrib/Parser/DATAS/01 - Dungeons Raids/01 - Classic/2.5 Ruins of Ahn'Qiraj.lua
@@ -521,6 +521,7 @@ root(ROOTS.Instances, expansion(EXPANSION.CLASSIC, applyclassicphase(PHASE_FIVE,
 				},
 				["groups"] = {
 					-- Class Books
+					-- #if BEFORE 4.0.1
 					cl(DRUID, bubbleDown({ ["classes"] = { DRUID } }, {
 						i(21294, {	-- Book of Healing Touch XI
 							["spellID"] = 25297,	-- Healing Touch XI
@@ -646,7 +647,8 @@ root(ROOTS.Instances, expansion(EXPANSION.CLASSIC, applyclassicphase(PHASE_FIVE,
 							["rank"] = 6,
 						}),
 					})),
-
+					-- #endif
+					
 					-- Enchants
 					i(20736),	-- Formula: Enchant Cloak - Dodge (RECIPE!)
 					i(20734),	-- Formula: Enchant Cloak - Stealth (RECIPE!)

--- a/.contrib/Parser/DATAS/02 - Outdoor Zones/02 Eastern Kingdoms/Burning Steppes.lua
+++ b/.contrib/Parser/DATAS/02 - Outdoor Zones/02 Eastern Kingdoms/Burning Steppes.lua
@@ -544,7 +544,11 @@ root(ROOTS.Zones, m(EASTERN_KINGDOMS, {
 					["timeline"] = { ADDED_4_0_3 },
 					["maps"] = { BLACKROCK_DEPTHS },
 					["races"] = HORDE_ONLY,
+					-- #if AFTER 10.0.1
 					["lvl"] = lvlsquish(56, 56, 20),
+					-- #else
+					["lvl"] = { 48, 57 },
+					-- #endif
 					-- this quest was level locked for characters above level 56 before Shadowlands level squish
 				}),
 				q(7630, {	-- Arcanite

--- a/.contrib/Parser/lib/Structures/Professions/Engineering.lua
+++ b/.contrib/Parser/lib/Structures/Professions/Engineering.lua
@@ -384,7 +384,7 @@ WRATH_ENGINEERING = applyclassicphase(WRATH_PHASE_ONE, bubbleDown({ ["timeline"]
 		r(67839, {["timeline"] = {ADDED_3_2_0}}),	-- Mind Amplification Dish
 		r(55016),	-- Nitro Boosts
 		r(63770, {["timeline"] = {ADDED_3_0_3, REMOVED_6_0_2}}),	-- Reticulated Armor Webbing
-		r(63765, {["timeline"] = {ADDED_3_0_3, REMOVED_6_0_2}}),	-- Springy Arachnoweave
+		r(63765, {["timeline"] = {ADDED_3_0_3, REMOVED_4_0_1}}),	-- Springy Arachnoweave
 	}),
 	filter(MISC, {
 		r(56461),	-- Bladed Pickaxe


### PR DESCRIPTION
Urga: Removed Springy Arachnoweave from Engineering as it no longer exists in classic. Added a max level limit to the "Adventurer's Wanted: Blackrock Depths" quest. Removed AQ20 class books as they are no longer learnable or collectable.