### PR TITLE
Update Townlong Steppes.lua

### DIFF
--- a/.contrib/Parser/DATAS/07 - Events/Remix Mists of Pandaria/Outdoor Zones/Townlong Steppes.lua
+++ b/.contrib/Parser/DATAS/07 - Events/Remix Mists of Pandaria/Outdoor Zones/Townlong Steppes.lua
@@ -130,7 +130,6 @@ root(ROOTS.WorldEvents, applyevent(EVENTS.REMIX_MOP, n(REMIX_MOP, bubbleDown({ [
 					i(215487),	-- Hozen Waraxe (wowhead)
 					i(215621),	-- Imperial Warknife
 					i(216534),	-- Ironwood Deflector (wowhead)
-					i(216533),	-- Ironwood Shield
 					i(215894),	-- Jinyu Conduit
 					i(215987),	-- Jinyu Greatblade
 					i(215540),	-- Jinyu Shortbow (chest)


### PR DESCRIPTION
Ironwood Shield does not drop in Townlong Steppes. I have done a lot of farming, it didn't drop and Wowhead dropped by list and comments suggests the same thing: https://www.wowhead.com/item=216533/ironwood-shield#dropped-by