### PR TITLE
Add trash items (white/grey) filtering in Classic

### DIFF
--- a/locales/Default Locale.lua
+++ b/locales/Default Locale.lua
@@ -149,6 +149,8 @@ L.SETTINGS_MENU = {
 		MAIN_ONLY_TOOLTIP = "Turn this setting on if you additionally want ATT to *pretend* that you've earned all shared appearances not locked by a different race or class.\n\nAs an example, if you have collected a Hunter-Only Tier Piece from ICC and there is a shared appearance from the raid without class/race restrictions, ATT will *pretend* that you've earned that source of the appearance as well.\n\nNOTE: Switching to a different race/class will incorrectly report that you've earned appearance sources that you haven't collected for that new chararacter when unlocked in this way.";
 		ONLY_RWP = "Only RWP";
 		ONLY_RWP_TOOLTIP = "Enable this option to only track transmog that get removed from the game in the future. Only Items tagged with 'removed with patch' data count toward this. If you find an item not tagged that should be tagged, please let me know!\n\nYou can change which sort of loot displays for you based on the Filters tab.";
+		ONLY_NOT_TRASH = "Filter Trash Items";
+		ONLY_NOT_TRASH_TOOLTIP = "Enable this option to ignore white/grey items. Blizzard does not yet provide API for it in Classic.";
 		UNOFFICIAL_SUPPORT_TOOLTIP = "NOTE: At this time, official support is not provided by WoW's API, but ATT can track items or quest completion to make it functional in the addon.";
 
 		-- General Content

--- a/src/Classes/Item.Classic.lua
+++ b/src/Classes/Item.Classic.lua
@@ -195,6 +195,7 @@ app.CreateItem = app.CreateClass("Item", "itemID", itemFields,
 "AsTransmog", {
 	collectible = app.GameBuildVersion >= 40000 and function(t)
 		if t.collectibleAsCost then return true; end
+		if app.Settings.OnlyNotTrash and (not t.q or t.q < 2) then return false; end
 		return app.Settings.Collectibles.Transmog;
 	end or function(t)
 		if t.collectibleAsCost then return true; end

--- a/src/Settings/Classic Settings.lua
+++ b/src/Settings/Classic Settings.lua
@@ -82,6 +82,7 @@ local GeneralSettingsBase = {
 		["Thing:Transmog"] = app.GameBuildVersion >= 40000,
 		["DeathTracker"] = app.GameBuildVersion < 40000,
 		["Only:RWP"] = app.GameBuildVersion < 40000,
+		["Only:NotTrash"] = app.GameBuildVersion <= 40000,
 		["Skip:AutoRefresh"] = false,
 		["Show:CompletedGroups"] = false,
 		["Show:CollectedThings"] = false,
@@ -1126,6 +1127,7 @@ settings.UpdateMode = function(self, doRefresh)
 			filterSet.Event()
 		end
 		self.OnlyRWP = self:Get("Only:RWP");
+		self.OnlyNotTrash = self:Get("Only:NotTrash");
 	end
 	app.MODE_DEBUG_OR_ACCOUNT = app.MODE_DEBUG or app.MODE_ACCOUNT;
 

--- a/src/Settings/Pages/General.lua
+++ b/src/Settings/Pages/General.lua
@@ -263,6 +263,24 @@ if app.GameBuildVersion >= 40000 then	-- Transmog officially supported with Cata
 	end)
 	checkboxMainOnlyMode:SetATTTooltip(L.MAIN_ONLY_TOOLTIP)
 	checkboxMainOnlyMode:AlignBelow(checkboxTransmog, 1)
+	
+	local checkboxQualityFilter = child:CreateCheckBox(L.ONLY_NOT_TRASH,
+	function(self)
+		self:SetChecked(settings:Get("Only:NotTrash"))
+		if not settings:Get("Thing:Transmog") and not app.MODE_DEBUG then
+			self:Disable()
+			self:SetAlpha(0.4)
+		else
+			self:Enable()
+			self:SetAlpha(1)
+		end
+	end,
+	function(self)
+		settings:Set("Only:NotTrash", self:GetChecked());
+		settings:UpdateMode(1);
+	end)
+	checkboxQualityFilter:SetATTTooltip(L.ONLY_NOT_TRASH_TOOLTIP)
+	checkboxQualityFilter:AlignAfter(checkboxMainOnlyMode)
 else
 	local checkboxOnlyRWP = child:CreateCheckBox(L.ONLY_RWP,
 	function(self)


### PR DESCRIPTION
Add a new option to allow users to ignore white/grey items Appearances.

Tested on minilist and main panel.