### PR TITLE
Add missing attributes for DF pre-launch

### DIFF
--- a/.contrib/Parser/DATAS/07 - Events/Expansion PreLaunch Events/09 Dragonflight.lua
+++ b/.contrib/Parser/DATAS/07 - Events/Expansion PreLaunch Events/09 Dragonflight.lua
@@ -358,17 +358,6 @@ root(ROOTS.WorldEvents, n(EXPANSION_PRELAUNCH, bubbleDown({ ["timeline"] = { ADD
 				["coord"] = { 25.4, 55.2, STORMWIND_CITY },
 				["races"] = ALLIANCE_ONLY,
 			}),
-			q(72288, {	-- Stay awhile and listen: Baine and Mayla
-				["name"] = "Stay awhile and listen: Baine and Mayla",
-				["coord"] = { 55.9, 12.1, DUROTAR },
-				["races"] = HORDE_ONLY,
-			}),
-			q(72290, {	-- Stay awhile and listen: Cindrethresh and Emberthal
-				["name"] = "Stay awhile and listen: Cindrethresh and Emberthal",
-				["provider"] = { "n", 184858 },	-- Cindrethresh
-				["coord"] = { 55.6, 12.3, DUROTAR },
-				["races"] = HORDE_ONLY,
-			}),
 			q(72286, {	-- Stay awhile and listen: Genn Greymane
 				["qg"] = 194756,	-- Genn Greymane
 				["sourceQuests"] = {
@@ -389,10 +378,31 @@ root(ROOTS.WorldEvents, n(EXPANSION_PRELAUNCH, bubbleDown({ ["timeline"] = { ADD
 				["coord"] = { 27.1, 53.8, STORMWIND_CITY },
 				["races"] = ALLIANCE_ONLY,
 			}),
+			q(72288, {	-- Stay awhile and listen: Baine and Mayla
+				["name"] = "Stay awhile and listen: Baine and Mayla",
+				["sourceQuests"] = {
+					72256,	-- The Dark Talons [H]
+					65443,	-- Expeditionary Coordination [H]
+				},
+				["provider"] = { "n", 198411 },	-- Baine
+				["coord"] = { 55.9, 12.1, DUROTAR },
+				["races"] = HORDE_ONLY,
+			}),
 			q(72289, {	-- Stay awhile and listen: Lor'themar and Thalyssra
 				["name"] = "Stay awhile and listen: Lor'themar and Thalyssra",
+				["sourceQuests"] = {
+					72256,	-- The Dark Talons [H]
+					65443,	-- Expeditionary Coordination [H]
+				},
 				["provider"] = { "n", 184665 },	-- Lor'themar Theron
 				["coord"] = { 55.7, 12.2, DUROTAR },
+				["races"] = HORDE_ONLY,
+			}),
+			q(72290, {	-- Stay awhile and listen: Cindrethresh and Emberthal
+				["name"] = "Stay awhile and listen: Cindrethresh and Emberthal",
+				["sourceQuests"] = {72256},	-- The Dark Talons [H]
+				["provider"] = { "n", 184858 },	-- Cindrethresh
+				["coord"] = { 55.6, 12.3, DUROTAR },
 				["races"] = HORDE_ONLY,
 			}),
 		}),


### PR DESCRIPTION
- Adds the missing quest provider for baine and mayla
- Add missing sourceQuests for horde
- Re-order quests to have a neater appearance 

I'm new to AttTheThings contributing so I'm not 100% sure if providers or qp is the right attribute to use in this case. Also the source quests I added are needed before these mobs will appear, so I believe this is the correct spot for them.

Also completion of "65443 To the Dragon Isles!" makes these quests unobtainable. not sure if that has a place here or not. quest link: https://www.wowhead.com/quest=65444/to-the-dragon-isles