### PR TITLE
Fix Yor ID in timewalking

### DIFF
--- a/.contrib/Parser/DATAS/21 - Holidays/Timewalking.lua
+++ b/.contrib/Parser/DATAS/21 - Holidays/Timewalking.lua
@@ -1592,7 +1592,7 @@ root(ROOTS.Holidays, n(TIMEWALKING_HEADER, applyevent(EVENTS.TIMEWALKING_OUTLAND
 					{ "i", 225678, 1 },	-- Spare Key to Shaffar's Stasis Chamber
 					-- #endif
 				},
-				["creatureID"] = 22930,
+				["creatureID"] = 22927,
 				["groups"] = {
 					i(127422),	-- Mistshroud Tunic
 					i(127421),	-- Skystalker's Tunic


### PR DESCRIPTION
![imagen](https://github.com/user-attachments/assets/a6e4abc7-5977-4114-be0f-fff9316d9cad)

is using a wrong id only in timewalking