### PR TITLE
[Logic] Refactor ShouldExcludeFromTooltip

### DIFF
--- a/.contrib/Parser/lib/Functions/Function Templates.lua
+++ b/.contrib/Parser/lib/Functions/Function Templates.lua
@@ -71,7 +71,7 @@ FUNCTION_TEMPLATES = {
 			local OnInitName = "ShouldExcludeFromTooltipForBuffs_"..table.concat(buffs, "_")
 			ExportDB.OnInitDB[OnInitName] = [[~function(t)
 				local buffs={[]] .. table.concat(buffs, "]=1,[") .. [[]=1};
-				t.ShouldExcludeFromTooltip = function(t)
+				t.ShouldExcludeFromTooltipHelper = function(t)
 					local target = UnitExists("mouseover") and "mouseover" or "target";
 					for i=1,10,1 do
 						local id = select(10, UnitBuff(target,i));

--- a/src/Classes/Difficulty.lua
+++ b/src/Classes/Difficulty.lua
@@ -184,8 +184,7 @@ app.CreateDifficulty = app.CreateClass("Difficulty", "difficultyID", {
 			end
 			return true;
 		end
-		local parent = t.parent
-		return parent and parent.ShouldExcludeFromTooltip
+		return app.BaseClass.__class.ShouldExcludeFromTooltip(t)
 	end,
 },
 "Group", {

--- a/src/Classes/base.lua
+++ b/src/Classes/base.lua
@@ -230,6 +230,10 @@ local DefaultFields = {
 	end,
 	-- Base ShouldExcludeFromTooltip is false, so search upwards in hierarchy for a defined result
 	["ShouldExcludeFromTooltip"] = function(t)
+		-- If this t has a helper defined for exclusion
+		local helper = t.ShouldExcludeFromTooltipHelper
+		if helper and helper(t) then return true end
+
 		-- Whether or not to exclude this data from the source list in the tooltip.
 		local parent = t.parent
 		if parent then return parent.ShouldExcludeFromTooltip end


### PR DESCRIPTION
We don't need a field that calls another field which runs a helper function to recurse upwards in hierarchy to repeat the process.
If we consolidate the `ShouldExcludeFromTooltip` base field to perform the recursion and let overrides of `ShouldExcludeFromTooltip` determine whether that recursion should persist if their own implementation is not met, we get the exact same logic flow without the multiple extra chained steps.

I just don't have a way to _fully_ test the custom `ShouldExcludeFromTooltip` functionality in MoP Classic concerning the different dungeon 'Protocol X' buffs. If someone on Classic with high-level characters could:
* Pull this branch
* ~~Run `Parser for Classic (05 - Mists of Pandaria).bat`~~ **Helper in data is no longer changed**
* Go into a dungeon with/without the respective Protocol stuff active and verify that the tooltip on Encounters while within the dungeon matches what is expected

~~Then we can merge this in. The OnInit part of the FunctionTemplate change works fine, it's just the actual _execution of the ShouldExcludeFromTooltip functionality while within a dungeon for an NPC with/without the respective Buff being active_ that I can't test myself.~~
With the slight revision, the Helper can persist when needed on an _object_ and the field itself on a _class_ will recurse and check for the Helper on each recursed object.