### PR TITLE
cmd: add /att [t|target] command

### DIFF
--- a/src/Commands.lua
+++ b/src/Commands.lua
@@ -191,6 +191,22 @@ end, {
 	"Allows toggling the debug printing and monitoring of all game events that ATT handles.",
 })
 
+-- Allows a user to open a popout window for their target via /att [t|target]
+app.ChatCommands.Add({"t", "target"}, function(args)
+	local guid = UnitGUID("target");
+	if guid then
+		local npcID = select(6, ("-"):split(guid))
+		if npcID then
+			app.CreatePopoutForSearch("n:" .. npcID)
+		end
+	end
+
+	return true
+end, {
+	"Usage : /att [t|target]",
+	"Allows opening a popout window for your targeted NPC",
+})
+
 -- Allows adding a direct slash command(s) to the game
 -- NOTE: This is not super desirable to add so many slash commands.
 -- Please use app.ChatCommands.Add if possible to add a typical /att [command] [params] structured command with common handling


### PR DESCRIPTION
this pr adds in a new `/att target` command (with a short-hand `/att t`). the idea is specifically to create a popout window, to compare with `/att search`:

<img width="1009" height="432" alt="image" src="https://github.com/user-attachments/assets/4402adef-941d-4928-a981-63426a10fd8a" />

although it shows the same info, i find the explicit popout a bit easier to read: it tells me an est. amount of currency left, reduces the visual noise of the prime list, and also doesn't reset my scroll pos/which tabs are open.

not sure if this is a desired solution at all, but for me at least it felt useful enough to contribute ^^