### PR TITLE
Feature: Export Stylized Data

### DIFF
--- a/src/UI/Windows/Debugger.lua
+++ b/src/UI/Windows/Debugger.lua
@@ -245,7 +245,7 @@ local function ExportKeyValue(key, value)
 				str = str .. "\"" .. value .. "\",";
 			end
 		else
-			str = str .. value .. ",";
+			str = str .. tostring(value) .. ",";
 		end
 	end
 	return str;

--- a/src/UI/Windows/Debugger.lua
+++ b/src/UI/Windows/Debugger.lua
@@ -311,32 +311,34 @@ app:RegisterDataStyleExporter("raw", {
 })
 
 -- helpers for readable style
+local KnownShortcutsByType = {
+	Currency = "currency",
+	Header = "n",
+	Item = "i",
+	Map = "m",
+	NPC = "n",
+	Objective = "objective",
+	Quest = "q",
+}
 local function FormatReadableKey(data)
 	local hasKey = data and data.key
-	if not hasKey then return nil end
+	if not hasKey then return end
+
 	local id = data[hasKey]
-	if hasKey == "npcID" then
-		return "n("..id
-	elseif hasKey == "itemID" then
-		return "i("..id
-	elseif hasKey == "mapID" then
-		return "m("..id
-	elseif hasKey == "questID" then
-		return "q("..id
-	elseif hasKey == "objectiveID" then
-		return "objective("..id
-	elseif hasKey == "headerID" then
+	local shortcut = KnownShortcutsByType[data.__type]
+	-- unknown key shortcut, fall back to nil so we treat it as unkeyed
+	if not shortcut then return end
+
+	if hasKey == "headerID" then
 		for k,i in pairs(app.HeaderConstants) do
 			if i == id then
 				id = k;
 				break;
 			end
 		end
-		return "n("..id
-	else
-		-- unknown key, fall back to nil so we treat it as unkeyed
-		return nil
 	end
+
+	return shortcut.."("..(id or UNKNOWN)
 end
 
 local function HasUsefulFields(data)

--- a/src/UI/Windows/Debugger.lua
+++ b/src/UI/Windows/Debugger.lua
@@ -856,7 +856,7 @@ app:CreateWindow("Debugger", {
 			local loot, source, kind, lootID, info, dropLink
 			local ot, zero, server_id, instance_id, zone_uid, id, spawn_uid;
 			local slots = GetNumLootItems();
-			local tooltipName = GameTooltipTextLeft1:GetText() or nil
+			local tooltipName = GameTooltipTextLeft1:GetText() or UNKNOWN
 			-- technically this can be wrong in aoe-loot situations if you loot a rare and it includes loot from
 			-- regular mobs, etc.
 			local classification = UnitClassification("target") or ""

--- a/src/UI/Windows/Debugger.lua
+++ b/src/UI/Windows/Debugger.lua
@@ -380,6 +380,7 @@ KeySwaps = setmetatable({
 				return k
 			end
 		end
+		return id
 	end,
 }, { __index = function(t,k)
 	return DefaultKeyVal

--- a/src/UI/Windows/Debugger.lua
+++ b/src/UI/Windows/Debugger.lua
@@ -955,12 +955,5 @@ app:CreateWindow("Debugger", {
 		end
 		self:RegisterEvent("QUEST_ACCEPTED");
 	end,
-	OnUpdate = function(self, ...)
-		-- turn off the Visibility filter for the Debugger update
-		local filterVisible = app.Modules.Filter.Get.Visible();
-		app.Modules.Filter.Set.Visible();
-		self:DefaultUpdate(...);
-		app.Modules.Filter.Set.Visible(filterVisible);
-		return true;
-	end,
+	VisibilityFilter = app.ReturnTrue,
 });

--- a/src/UI/Windows/Debugger.lua
+++ b/src/UI/Windows/Debugger.lua
@@ -432,7 +432,7 @@ local function ReadableBeforeData(data, depth)
 	if data.key == "strKey" then return end
 	local indent = string.rep("\t", depth)
 	local keyStr = FormatReadableKey(data)
-	local name = data.basename or data.name or data.text
+	local name = data.name or data.basename or data.text or UNKNOWN
 	local anyOther = HasUsefulFields(data)
 	local hasGroups = data.g and #data.g > 0
 	local prefix = indent
@@ -856,6 +856,10 @@ app:CreateWindow("Debugger", {
 			local loot, source, kind, lootID, info, dropLink
 			local ot, zero, server_id, instance_id, zone_uid, id, spawn_uid;
 			local slots = GetNumLootItems();
+			local tooltipName = GameTooltipTextLeft1:GetText() or nil
+			-- technically this can be wrong in aoe-loot situations if you loot a rare and it includes loot from
+			-- regular mobs, etc.
+			local classification = UnitClassification("target") or ""
 			for i=1,slots,1 do
 				loot = GetLootSlotLink(i);
 				if loot then
@@ -882,12 +886,11 @@ app:CreateWindow("Debugger", {
 							app.print("Add",kind,"Loot",lootID,"from",ot,id)
 							if ot == "objectID" then
 								info = { key = ot, [ot] = tonumber(id), g = { info }};
-								info.basename = GameTooltipTextLeft1:GetText() or UNKNOWN
+								info.basename = tooltipName
 								app.print('ObjectID: '..info.objectID.. ' || ' .. 'Name: ' .. info.basename)
 								self:AddObjectWithHeader(app.HeaderConstants.TREASURES, info);
 							else
 								info = { key = ot, [ot] = tonumber(id), g = { info }};
-								local classification = UnitClassification("target") or "";
 								if classification == "rare" or classification == "rareelite" then
 									self:AddObjectWithHeader(app.HeaderConstants.RARES, info);
 								elseif classification == "worldboss" then

--- a/src/UI/Windows/Debugger.lua
+++ b/src/UI/Windows/Debugger.lua
@@ -533,12 +533,13 @@ app:CreateWindow("Debugger", {
 		-- Bubble Up the Maps
 		local mapID = app.CurrentMapID;
 		if mapID then
+			local mapInfo = C_Map_GetMapInfo(mapID);
+			header = not mapInfo and { key = "mapID", mapID = mapID, g = { header } } or header
 			local pos = C_Map_GetPlayerMapPosition(mapID, "player");
 			if pos then
 				local px, py = pos:GetXY();
 				info.coords = { [mapID] = { { px * 100, py * 100 } } };
 			end
-			local mapInfo = C_Map_GetMapInfo(mapID);
 			if mapInfo then
 				while mapID and mapID ~= 0 do
 					header = { key = "mapID", mapID = mapID, g = { header } }

--- a/src/UI/Windows/Debugger.lua
+++ b/src/UI/Windows/Debugger.lua
@@ -309,146 +309,144 @@ app:RegisterDataStyleExporter("raw", {
 	afterExport = function(data) return "} -- End Raw Data" end
 })
 
-local function ExportDataToString(data)
-	if data then
-		local id, name;
-		local restore = {};
-		if rawget(data, "basename") then
-			name = data.basename;
-			restore.basename = name;
-			data.basename = nil;
+-- helpers for readable style
+local function FormatReadableKey(data)
+	local hasKey = data and data.key
+	if not hasKey then return nil end
+	local id = data[hasKey]
+	if hasKey == "npcID" then
+		return "n("..id
+	elseif hasKey == "itemID" then
+		return "i("..id
+	elseif hasKey == "mapID" then
+		return "m("..id
+	elseif hasKey == "questID" then
+		return "q("..id
+	elseif hasKey == "objectiveID" then
+		return "objective("..id
+	elseif hasKey == "headerID" then
+		for k,i in pairs(app.HeaderConstants) do
+			if i == id then
+				id = k;
+				break;
+			end
+		end
+		return "n("..id
+	else
+		-- unknown key, fall back to nil so we treat it as unkeyed
+		return nil
+	end
+end
+
+local function ReadableBeforeData(data, depth)
+	if not data or data.key == "strKey" then return end
+	local indent = string.rep("\t", depth>0 and depth-1 or 0)
+	local keyStr = FormatReadableKey(data)
+	local name = data.basename or data.name or data.text
+	local anyOther = false
+	for k,v in pairs(data) do
+		if not CleanFields[k] and k ~= "g" and k ~= data.key then
+			anyOther = true; break
+		end
+	end
+	local hasGroups = data.g and #data.g > 0
+	local prefix = indent
+	if keyStr then
+		if anyOther or hasGroups then
+			prefix = prefix .. keyStr .. ", {"
 		else
-			name = rawget(data, "name");
+			prefix = prefix .. keyStr .. ")"
+		end
+	else
+		prefix = prefix .. "{"
+	end
+	if name then
+		if keyStr and not (anyOther or hasGroups) then
+			prefix = prefix .. ",\t-- " .. name
+		else
+			prefix = prefix .. " -- " .. name
+		end
+	end
+	return prefix
+end
+
+local function ReadableMain(data, depth)
+	if data and data.key == "strKey" then return end
+	local indent = string.rep("\t", depth)
+	local sub = indent .. "\t"
+	local str = ""
+	for k,v in pairs(data) do
+		if not CleanFields[k] and k ~= "g" and k ~= data.key then
+			str = str .. "\n" .. sub .. ExportKeyValue(k,v):gsub("\n", "\n"..sub)
+		end
+	end
+	return str
+end
+
+local function ReadableBeforeSub(data, depth)
+	local indent = string.rep("\t", depth)
+	local anyOther = false
+	for k in pairs(data) do
+		if not CleanFields[k] and k ~= "g" then anyOther = true; break end
+	end
+	if not anyOther then
+		-- no non-clean fields (and no keyed value), just let recursion handle children
+		return
+	end
+	local indent1 = indent .. "\t"
+	return "\n" .. indent1 .. "groups = {"
+end
+
+local function ReadableAfterSub(data, depth)
+	local indent = string.rep("\t", depth)
+	local anyOther = false
+	for k in pairs(data) do
+		if not CleanFields[k] and k ~= "g" then anyOther = true; break end
+	end
+	if not anyOther then return end
+	local indent1 = indent .. "\t"
+	return "\n" .. indent1 .. "},"
+end
+
+local function ReadableAfterData(data, depth)
+	if not data or data.key == "strKey" then return end
+	local indent = string.rep("\t", depth>0 and depth-1 or 0)
+	local keyStr = FormatReadableKey(data)
+	local anyOther = false
+	for k,v in pairs(data) do
+		if not CleanFields[k] and k ~= "g" and k ~= data.key then
+			anyOther = true; break
+		end
+	end
+	local hasGroups = data.g and #data.g > 0
+	if keyStr then
+		if anyOther or hasGroups then
+			return "\n" .. indent .. "}),"
+		else
+			-- simple keyed entry (no other fields, no groups)
+			-- if we added a name comment in beforeData we already included a comma
+			local name = data.basename or data.name or data.text
 			if name then
-				restore.name = name;
-				data.name = nil;
+				return ""
 			else
-				name = rawget(data, "text")
-				if name then
-					restore.text = name;
-					data.text = nil;
-				end
+				return ","
 			end
 		end
-		
-		local hasKey = data.key;
-		if hasKey then
-			id = data[hasKey];
-			restore[hasKey] = id;
-			
-			-- Some classes have 2 parameters and will need to rip out some data to restore later
-			-- Export the shortcut used by the key
-			if hasKey == "npcID" then
-				hasKey = "n(" .. id;
-			elseif hasKey == "itemID" then
-				hasKey = "i(" .. id;
-			elseif hasKey == "mapID" then
-				hasKey = "m(" .. id;
-			elseif hasKey == "questID" then
-				hasKey = "q(" .. id;
-			elseif hasKey == "objectiveID" then
-				hasKey = "objective(" .. id;
-			elseif hasKey == "headerID" then
-				for k,i in pairs(app.HeaderConstants) do
-					if i == id then
-						id = k;
-						break;
-					end
-				end
-				hasKey = "n(" .. id;
-			else
-				-- Unhandled key, just inject it raw.
-				for key,value in pairs(restore) do
-					data[key] = value;
-				end
-				restore = {};
-				hasKey = nil;
-			end
-			if hasKey then
-				if not name then name = data.name; end
-				data[data.key] = nil;
-			end
-		end
-		
-		-- Build the string for non-keyed fields
-		local str = "";
-		local anyKeys;
-		local hasG = data.g;
-		if hasG then
-			restore.g = hasG;
-			data.g = nil;
-		end
-		for key,value in pairs(data) do
-			if not CleanFields[key] then
-				str = str .. "\n\t" .. ExportKeyValue(key,value):gsub("\n", "\n\t");
-				anyKeys = true;
-			end
-		end
-		
-		-- Assign the groups back and export relative groups
-		if hasG and #hasG > 0 then
-			if anyKeys then
-				str = str .. "\n\tgroups = {";
-				for i,o in ipairs(hasG) do
-					str = str .. "\n\t\t" .. (ExportDataToString(o):gsub("\n", "\n\t\t"));
-				end
-				str = str .. "\n\t},";
-			else
-				anyKeys = true;
-				for i,o in ipairs(hasG) do
-					str = str .. "\n\t" .. (ExportDataToString(o):gsub("\n", "\n\t"));
-				end
-			end
-		end
-		
-		-- Restore the silenced fields back to their original values.
-		for key,value in pairs(restore) do
-			data[key] = value;
-		end
-		if anyKeys then
-			if hasKey then
-				if name then
-					return hasKey .. ", {\t-- " .. name .. str .. "\n}),";
-				else
-					return hasKey .. ", {" .. str .. "\n}),";
-				end
-			else
-				if name then
-					return "{\t-- " .. name .. str .. "\n},";
-				else
-					return "{" .. str .. "\n},";
-				end
-			end
-		else
-			if hasKey then
-				if name then
-					return hasKey .. "),\t-- " .. name .. str;
-				else
-					return hasKey .. ")," .. str;
-				end
-			else
-				if name then
-					return "{\t-- " .. name .. str .. "\n},";
-				else
-					return "{" .. str .. "\n},";
-				end
-			end
-		end
-	end
-	return "nil,";
-end
-local function OnClick_ExportData(row, button)
-	-- TODO: It would be neat to be able to export singular objects
-	if button == "LeftButton" and IsAltKeyDown() then
-		local str = ExportDataToString(row.ref);
-		if str then
-			app:ShowPopupDialogWithMultiLineEditBox(str, nil, "Export Results");
-		else
-			app.print("Nothing to export");
-		end
-		return true;
+	else
+		return "\n" .. indent .. "},"
 	end
 end
+
+-- register the 'readable' style exporter
+app:RegisterDataStyleExporter("readable", {
+	main = ReadableMain,
+	beforeSub = ReadableBeforeSub,
+	afterSub = ReadableAfterSub,
+	beforeData = ReadableBeforeData,
+	afterData = ReadableAfterData,
+	beforeExport = function(data) return "{ -- Readable Data from "..(data and (data.name or (data.window and data.window.Suffix)) or "") end,
+	afterExport = function(data) return "} -- End Readable Data" end,
+})
 
 -- Uncomment this section if you need to enable Debugger:
 -- Retail Currently uses [/att debugger] as defined below
@@ -568,24 +566,7 @@ app:CreateWindow("Debugger", {
 					visible = true,
 					count = 0,
 					OnClick = function(row, button)
-						local str;
-						for i,o in ipairs(self.data.g) do
-							if o.key ~= "strKey" then
-								local substr = ExportDataToString(CloneObject(o));
-								if substr then
-									if str then
-										str = str .. "\n" .. substr;
-									else
-										str = substr;
-									end
-								end
-							end
-						end
-						if str then
-							app:ShowPopupDialogWithMultiLineEditBox(str, nil, "Export Results");
-						else
-							app.print("Nothing to export");
-						end
+						app:ExportStylizedData(self, "readable");
 						return true;
 					end,
 				}),

--- a/src/UI/Windows/Debugger.lua
+++ b/src/UI/Windows/Debugger.lua
@@ -257,12 +257,13 @@ local function ExportRawDataToString(data, depth)
 	local indent = string.rep("\t", depth)
 	if data then
 		local datalines = {}
+		local keyindent = "\n" .. indent
 		for key,value in pairs(data) do
 			if not CleanFields[key] and key ~= "g" then
-				datalines[#datalines + 1] = indent .. ExportKeyValue(key,value):gsub("\n", "\n" .. indent)
+				datalines[#datalines + 1] = indent .. ExportKeyValue(key,value):gsub("\n", keyindent)
 			end
 		end
-		return app.TableConcat(datalines, nil, nil, "\n")
+		return #datalines > 0 and app.TableConcat(datalines, nil, nil, "\n") or nil
 	end
 	return indent .. "nil,"
 end
@@ -338,17 +339,23 @@ local function FormatReadableKey(data)
 	end
 end
 
+local function HasUsefulFields(data)
+	for k in pairs(data) do
+		if not CleanFields[k]
+			and k ~= "g"
+			and k ~= data.key
+		then
+			return true
+		end
+	end
+end
+
 local function ReadableBeforeData(data, depth)
 	if not data or data.key == "strKey" then return end
 	local indent = string.rep("\t", depth)
 	local keyStr = FormatReadableKey(data)
 	local name = data.basename or data.name or data.text
-	local anyOther = false
-	for k,v in pairs(data) do
-		if not CleanFields[k] and k ~= "g" and k ~= data.key then
-			anyOther = true; break
-		end
-	end
+	local anyOther = HasUsefulFields(data)
 	local hasGroups = data.g and #data.g > 0
 	local prefix = indent
 	if keyStr then
@@ -370,72 +377,57 @@ local function ReadableBeforeData(data, depth)
 	return prefix
 end
 
+local IgnoredForReadable = setmetatable({
+	g = true,
+	name = true,
+	basename = true,
+	text = true,
+}, { __index = CleanFields })
 local function ReadableMain(data, depth)
 	if data and data.key == "strKey" then return end
-	local indent = string.rep("\t", depth)
-	local sub = indent .. "\t"
-	local str = ""
-	for k,v in pairs(data) do
-		-- ignore cleaned fields, groups, the keyed identifier, and name/text fields
-		if not CleanFields[k] and k ~= "g" and k ~= data.key
-			and k ~= "name" and k ~= "basename" and k ~= "text" then
-			str = str .. "\n" .. sub .. ExportKeyValue(k,v):gsub("\n", "\n"..sub)
+	depth = depth or 0
+	local indent = string.rep("\t", depth + 1)
+	if data then
+		local datalines = {}
+		local keyindent = "\n" .. indent
+		for key,value in pairs(data) do
+			if not IgnoredForReadable[key] and key ~= data.key then
+				datalines[#datalines + 1] = indent .. ExportKeyValue(key,value):gsub("\n", keyindent)
+			end
 		end
+		return #datalines > 0 and app.TableConcat(datalines, nil, nil, "\n") or nil
 	end
-	-- strip any leading newline (we'll join entries with a newline anyway)
-	str = str:gsub("^\n", "")
-	if str == "" then
-		return nil
-	end
-	return str
+	return indent .. "nil,"
+end
+
+local function ReadableDepthShift(data)
+	return HasUsefulFields(data) and 2 or 1
 end
 
 local function ReadableBeforeSub(data, depth)
-	local indent = string.rep("\t", depth)
-	local anyOther = false
-	for k in pairs(data) do
-		if not CleanFields[k] and k ~= "g" and k ~= data.key then anyOther = true; break end
-	end
-	if not anyOther then
-		-- only key/ g present, nothing to wrap
+	if not HasUsefulFields(data) then
+		-- only key/g present, nothing to wrap
 		return
 	end
-	return indent .. "\tgroups = {"
+	return string.rep("\t", depth + 1) .. "groups = {"
 end
 
 local function ReadableAfterSub(data, depth)
-	local indent = string.rep("\t", depth)
-	local anyOther = false
-	for k in pairs(data) do
-		if not CleanFields[k] and k ~= "g" and k ~= data.key then anyOther = true; break end
-	end
-	if not anyOther then return end
-	return indent .. "\t},"
+	if not HasUsefulFields(data) then return end
+	return string.rep("\t", depth + 1) .. "},"
 end
 
 local function ReadableAfterData(data, depth)
 	if not data or data.key == "strKey" then return end
 	local indent = string.rep("\t", depth)
 	local keyStr = FormatReadableKey(data)
-	local anyOther = false
-	for k,v in pairs(data) do
-		if not CleanFields[k] and k ~= "g" and k ~= data.key then
-			anyOther = true; break
-		end
-	end
 	local hasGroups = data.g and #data.g > 0
 	if keyStr then
-		if anyOther or hasGroups then
+		if HasUsefulFields(data) or hasGroups then
 			return indent .. "}),"
 		else
 			-- simple keyed entry (no other fields, no groups)
-			-- if we added a name comment in beforeData we already included a comma
-			local name = data.basename or data.name or data.text
-			if name then
-				return ""
-			else
-				return ","
-			end
+			return
 		end
 	else
 		return indent .. "},"
@@ -449,6 +441,7 @@ app:RegisterDataStyleExporter("readable", {
 	afterSub = ReadableAfterSub,
 	beforeData = ReadableBeforeData,
 	afterData = ReadableAfterData,
+	depthShift = ReadableDepthShift,
 	beforeExport = function(data) return "{ -- Readable Data from "..(data and (data.name or (data.window and data.window.Suffix)) or "") end,
 	afterExport = function(data) return "} -- End Readable Data" end,
 })

--- a/src/UI/Windows/Debugger.lua
+++ b/src/UI/Windows/Debugger.lua
@@ -250,41 +250,65 @@ local function ExportKeyValue(key, value)
 	end
 	return str;
 end
-local function ExportRawDataToString(data)
+local function ExportRawDataToString(data, depth)
+	-- ignore string-keyed entries; they should not be exported
+	if data and data.key == "strKey" then return end
+	depth = depth or 0
+	local indent = string.rep("\t", depth)
 	if data then
-		local str = "{";
-		local hasG = data.g;
-		if hasG then data.g = nil; end
-		
-		local anyOtherKeys;
+		local datalines = {}
 		for key,value in pairs(data) do
-			if not CleanFields[key] then
-				str = str .. "\n\t" .. ExportKeyValue(key,value):gsub("\n", "\n\t");
-				anyOtherKeys = true;
+			if not CleanFields[key] and key ~= "g" then
+				datalines[#datalines + 1] = indent .. ExportKeyValue(key,value):gsub("\n", "\n" .. indent)
 			end
 		end
-		
-		-- Assign the groups back
-		if hasG then
-			data.g = hasG;
-			if #hasG > 0 then
-				if anyOtherKeys then
-					str = str .. "\n\tg = {";
-					for i,o in ipairs(hasG) do
-						str = str .. "\n\t\t" .. (ExportRawDataToString(o):gsub("\n", "\n\t\t"));
-					end
-					str = str .. "\n\t}";
-				else
-					for i,o in ipairs(hasG) do
-						str = str .. "\n\t" .. (ExportRawDataToString(o):gsub("\n", "\n\t"));
-					end
-				end
-			end
-		end
-		return str .. "\n},";
+		return app.TableConcat(datalines, nil, nil, "\n")
 	end
-	return "nil,";
+	return indent .. "nil,"
 end
+local function RawBeforeSub(data, depth)
+	local indent = string.rep("\t", depth)
+	local anyOtherKeys = false
+	for key in pairs(data) do
+		if not CleanFields[key] then
+			anyOtherKeys = true
+			break
+		end
+	end
+	if anyOtherKeys then
+		return indent .. "g = {"
+	else
+		return indent .. "\t{"
+	end
+end
+local function RawAfterSub(data, depth)
+	local indent = string.rep("\t", depth)
+	local anyOtherKeys = false
+	for key in pairs(data) do
+		if not CleanFields[key] then
+			anyOtherKeys = true
+			break
+		end
+	end
+	if anyOtherKeys then
+		return indent .. "},"
+	else
+		return indent .. "\t},"
+	end
+end
+
+-- register the 'raw' style exporter
+app:RegisterDataStyleExporter("raw", {
+	main = ExportRawDataToString,
+	beforeSub = RawBeforeSub,
+	afterSub = RawAfterSub,
+	-- TODO: if not all items are loaded the .name can be empty, perhaps add a full scan of .name then export once all return??
+	beforeData = function(data, depth) if data and data.key ~= "strKey" then return string.rep("\t", depth>0 and depth-1 or 0).."{"..(data.name and (" -- "..data.name) or "") end end,
+	afterData = function(data, depth) if data and data.key ~= "strKey" then return string.rep("\t", depth>0 and depth-1 or 0).."}," end end,
+	beforeExport = function(data) return "{ -- Raw Data from "..(data and (data.name or (data.window and data.window.Suffix)) or "") end,
+	afterExport = function(data) return "} -- End Raw Data" end
+})
+
 local function ExportDataToString(data)
 	if data then
 		local id, name;
@@ -534,24 +558,7 @@ app:CreateWindow("Debugger", {
 					visible = true,
 					count = 0,
 					OnClick = function(row, button)
-						local str;
-						for i,o in ipairs(self.data.g) do
-							if o.key ~= "strKey" then
-								local substr = ExportRawDataToString(CloneObject(o));
-								if substr then
-									if str then
-										str = str .. "\n" .. substr;
-									else
-										str = substr;
-									end
-								end
-							end
-						end
-						if str then
-							app:ShowPopupDialogWithMultiLineEditBox(str, nil, "Export Results");
-						else
-							app.print("Nothing to export");
-						end
+						app:ExportStylizedData(self, "raw");
 						return true;
 					end,
 				}),

--- a/src/UI/Windows/Debugger.lua
+++ b/src/UI/Windows/Debugger.lua
@@ -340,7 +340,7 @@ end
 
 local function ReadableBeforeData(data, depth)
 	if not data or data.key == "strKey" then return end
-	local indent = string.rep("\t", depth>0 and depth-1 or 0)
+	local indent = string.rep("\t", depth)
 	local keyStr = FormatReadableKey(data)
 	local name = data.basename or data.name or data.text
 	local anyOther = false
@@ -393,8 +393,7 @@ local function ReadableBeforeSub(data, depth)
 		-- no non-clean fields (and no keyed value), just let recursion handle children
 		return
 	end
-	local indent1 = indent .. "\t"
-	return "\n" .. indent1 .. "groups = {"
+	return indent .. "\tgroups = {"
 end
 
 local function ReadableAfterSub(data, depth)
@@ -404,13 +403,12 @@ local function ReadableAfterSub(data, depth)
 		if not CleanFields[k] and k ~= "g" then anyOther = true; break end
 	end
 	if not anyOther then return end
-	local indent1 = indent .. "\t"
-	return "\n" .. indent1 .. "},"
+	return indent .. "\t},"
 end
 
 local function ReadableAfterData(data, depth)
 	if not data or data.key == "strKey" then return end
-	local indent = string.rep("\t", depth>0 and depth-1 or 0)
+	local indent = string.rep("\t", depth)
 	local keyStr = FormatReadableKey(data)
 	local anyOther = false
 	for k,v in pairs(data) do
@@ -421,7 +419,7 @@ local function ReadableAfterData(data, depth)
 	local hasGroups = data.g and #data.g > 0
 	if keyStr then
 		if anyOther or hasGroups then
-			return "\n" .. indent .. "}),"
+			return indent .. "}),"
 		else
 			-- simple keyed entry (no other fields, no groups)
 			-- if we added a name comment in beforeData we already included a comma
@@ -433,7 +431,7 @@ local function ReadableAfterData(data, depth)
 			end
 		end
 	else
-		return "\n" .. indent .. "},"
+		return indent .. "},"
 	end
 end
 

--- a/src/UI/Windows/Debugger.lua
+++ b/src/UI/Windows/Debugger.lua
@@ -291,6 +291,12 @@ local function ExportKeyValue(key, value)
 	end
 	return str;
 end
+local IgnoredForRaw = setmetatable({
+	g = true,
+	name = true,
+	basename = true,
+	text = true,
+}, { __index = CleanFields })
 local function ExportRawDataToString(data, depth)
 	-- ignore string-keyed entries; they should not be exported
 	if data and data.key == "strKey" then return end
@@ -300,7 +306,7 @@ local function ExportRawDataToString(data, depth)
 		local datalines = {}
 		local keyindent = "\n" .. indent
 		for key,value in pairs(data) do
-			if not CleanFields[key] and key ~= "g" then
+			if not IgnoredForRaw[key] then
 				datalines[#datalines + 1] = indent .. ExportKeyValue(key,value):gsub("\n", keyindent)
 			end
 		end
@@ -338,12 +344,14 @@ local function RawAfterSub(data, depth)
 		return indent .. "\t},"
 	end
 end
+local function RawDepthShift(data) return 2 end
 
 -- register the 'raw' style exporter
 app:RegisterDataStyleExporter("raw", {
 	main = ExportRawDataToString,
 	beforeSub = RawBeforeSub,
 	afterSub = RawAfterSub,
+	depthShift = RawDepthShift,
 	-- TODO: if not all items are loaded the .name can be empty, perhaps add a full scan of .name then export once all return??
 	beforeData = function(data, depth) if data and data.key ~= "strKey" then return string.rep("\t", depth>0 and depth-1 or 0).."{"..(data.name and (" -- "..data.name) or "") end end,
 	afterData = function(data, depth) if data and data.key ~= "strKey" then return string.rep("\t", depth>0 and depth-1 or 0).."}," end end,

--- a/src/UI/Windows/Debugger.lua
+++ b/src/UI/Windows/Debugger.lua
@@ -212,7 +212,8 @@ local function ExportKeyValue(key, value)
 		for mapID,coordsForMap in pairs(value) do
 			str = str .. "\t[" .. mapID .. "] = {\n";
 			for i,o in ipairs(coordsForMap) do
-				str = str .. "\t\t{ " .. o[1] .. ", " .. o[2] .. " },\n";
+				-- floor coords to nearest tenth
+				str = str .. "\t\t{ " .. ("%.1f"):format(app.round(o[1], 1)) .. ", " .. ("%.1f"):format(app.round(o[2], 1)) .. " },\n";
 			end
 			str = str .. "\t},\n";
 		end

--- a/src/UI/Windows/Debugger.lua
+++ b/src/UI/Windows/Debugger.lua
@@ -462,7 +462,6 @@ app:CreateWindow("Debugger", {
 		-- Bubble Up the Maps
 		local mapID = app.CurrentMapID;
 		if mapID then
-			header = { key = "mapID", ["mapID"] = mapID, ["g"] = { header } };
 			local pos = C_Map_GetPlayerMapPosition(mapID, "player");
 			if pos then
 				local px, py = pos:GetXY();
@@ -471,7 +470,7 @@ app:CreateWindow("Debugger", {
 			local mapInfo = C_Map_GetMapInfo(mapID);
 			if mapInfo then
 				while mapID and mapID ~= 0 do
-					header = { key = "mapID", ["mapID"] = mapID, ["g"] = { header } };
+					header = { key = "mapID", mapID = mapID, g = { header } }
 					mapInfo = C_Map_GetMapInfo(mapID);
 					mapID = mapInfo and mapInfo.parentMapID or 0;
 				end

--- a/src/UI/Windows/Debugger.lua
+++ b/src/UI/Windows/Debugger.lua
@@ -1,7 +1,7 @@
 -- App locals
 local appName, app = ...;
-local type,wipe,ipairs,pairs,rawget,select,tinsert,tremove,tonumber, math_floor
-	= type,wipe,ipairs,pairs,rawget,select,tinsert,tremove,tonumber, math.floor
+local type,wipe,ipairs,pairs,rawget,select,tinsert,tonumber, math_floor,setmetatable
+	= type,wipe,ipairs,pairs,rawget,select,tinsert,tonumber, math.floor,setmetatable
 
 -- WoW API Cache
 local C_Map_GetPlayerMapPosition, C_Map_GetMapInfo
@@ -95,6 +95,14 @@ local CleanFields = {
 	__canretry = 1,
 	SortType = 1,
 	OnClick = 1,
+	__FillGroups = 1,
+	_lastshown = 1,
+	_fillcomplete = 1,
+	back = 1,
+	indent = 1,
+	__class = 1,
+	window = 1,
+	__ExportTEMP = 1,
 };
 local function CleanObject(obj)
 	if obj == nil then return end
@@ -193,60 +201,93 @@ local function GetNameFromCost(costType, id, count)
 		return (count > 1 and ("x" .. count .. " ") or "") .. (app.GetNameFromProvider(costType, id) or UNKNOWN);
 	end
 end
-local function ExportKeyValue(key, value)
-	local str = key .. " = ";
-	if key == "providers" then
-		str = str .. "{\n";
+local ExportKeyValueHandlers = {
+	providers = function(key, value)
+		local lines = {"{"};
 		for i,o in ipairs(value) do
-			str = str .. "\t{ \"" .. o[1] .. "\", " .. o[2] .. " },\t-- " .. (app.GetNameFromProvider(o[1], o[2]) or UNKNOWN) .. "\n";
+			lines[#lines + 1] = "\t{ \"" .. o[1] .. "\", " .. o[2] .. " },\t-- " .. (app.GetNameFromProvider(o[1], o[2]) or UNKNOWN);
 		end
-		str = str .. "},";
-	elseif key == "crs" or key == "qgs" then
-		str = str .. "{\n";
+		lines[#lines + 1] = "},";
+		return app.TableConcat(lines, nil, nil, "\n");
+	end,
+	crs = function(key, value)
+		local lines = {"{"};
 		for i,id in ipairs(value) do
-			str = str .. "\t" .. id .. ",\t-- " .. (app.NPCNameFromID[id] or UNKNOWN) .. "\n";
+			lines[#lines + 1] = "\t" .. id .. ",\t-- " .. (app.NPCNameFromID[id] or UNKNOWN);
 		end
-		str = str .. "},";
-	elseif key == "coords" then
-		str = str .. "{\n";
+		lines[#lines + 1] = "},";
+		return app.TableConcat(lines, nil, nil, "\n");
+	end,
+	coords = function(key, value)
+		local lines = {"{"};
 		for mapID,coordsForMap in pairs(value) do
-			str = str .. "\t[" .. mapID .. "] = {\n";
+			lines[#lines + 1] = "\t[" .. mapID .. "] = {\t-- " .. (app.GetMapName(mapID) or UNKNOWN)
 			for i,o in ipairs(coordsForMap) do
 				-- floor coords to nearest tenth
-				str = str .. "\t\t{ " .. ("%.1f"):format(app.round(o[1], 1)) .. ", " .. ("%.1f"):format(app.round(o[2], 1)) .. " },\n";
+				lines[#lines + 1] = "\t\t{ " .. ("%.1f"):format(app.round(o[1], 1)) .. ", " .. ("%.1f"):format(app.round(o[2], 1)) .. " },";
 			end
-			str = str .. "\t},\n";
+			lines[#lines + 1] = "\t},";
 		end
-		str = str .. "},";
-	elseif key == "cost" then
+		lines[#lines + 1] = "},";
+		return app.TableConcat(lines, nil, nil, "\n");
+	end,
+	cost = function(key, value)
 		if type(value) == "number" then
 			-- This is simply a gold value
-			str = str .. value .. ",\t-- " .. GetMoneyString(value);
+			return value .. ",\t-- " .. GetMoneyString(value);
 		else
 			-- This is the traditional cost format.
-			str = str .. "{\n";
+			local lines = {"{"};
 			for i,o in ipairs(value) do
-				str = str .. "\t{ \"" .. o[1] .. "\", " .. o[2] .. ", " .. (o[3] or 1) .. " },\t-- ".. GetNameFromCost(o[1], o[2], o[3]) .. "\n";
+				lines[#lines + 1] = "\t{ \"" .. o[1] .. "\", " .. o[2] .. ", " .. (o[3] or 1) .. " },\t-- ".. GetNameFromCost(o[1], o[2], o[3]);
 			end
-			str = str .. "},";
+			lines[#lines + 1] = "},";
+			return app.TableConcat(lines, nil, nil, "\n");
 		end
-	elseif key == "r" then
+	end,
+	r = function(key, value)
 		-- "r" is a shortcut for "races", where the whole of the faction can do a thing
-		str = "races = " .. (value == 2 and "ALLIANCE_ONLY" or "HORDE_ONLY") .. ",";
-	else
-		if not DefaultParsing[key] then
-			print("DEFAULT PARSING FOR KEY", key);
-			DefaultParsing[key] = true;
+		return "races = " .. (value == 2 and "ALLIANCE_ONLY" or "HORDE_ONLY") .. ",";
+	end,
+	maps = function(key, value)
+		local lines = {"{"};
+		for i,id in ipairs(value) do
+			lines[#lines + 1] = "\t" .. id .. ",\t-- " .. (app.GetMapName(id) or UNKNOWN);
 		end
-		if type(value) == "string" then
-			if value:find("\"") or value:find("\n") then
-				str = str .. "[[" .. value .. "]],";
-			else
-				str = str .. "\"" .. value .. "\",";
-			end
+		lines[#lines + 1] = "},";
+		return app.TableConcat(lines, nil, nil, "\n");
+	end,
+	sourceQuests = function(key, value)
+		local lines = {"{"};
+		for i,id in ipairs(value) do
+			lines[#lines + 1] = "\t" .. id .. ",\t-- " .. (app.GetQuestName(id) or UNKNOWN);
+		end
+		lines[#lines + 1] = "},";
+		return app.TableConcat(lines, nil, nil, "\n");
+	end,
+}
+ExportKeyValueHandlers.qgs = ExportKeyValueHandlers.crs
+ExportKeyValueHandlers.nextQuests = ExportKeyValueHandlers.sourceQuests
+
+local function ExportKeyValue(key, value)
+	local handler = ExportKeyValueHandlers[key];
+	if handler then
+		return key .. " = " .. handler(key, value);
+	end
+	-- Default parsing for unrecognized keys
+	if not DefaultParsing[key] then
+		print("DEFAULT PARSING FOR KEY", key);
+		DefaultParsing[key] = true;
+	end
+	local str = key .. " = ";
+	if type(value) == "string" then
+		if value:find("\"") or value:find("\n") then
+			str = str .. "[[" .. value .. "]],";
 		else
-			str = str .. tostring(value) .. ",";
+			str = str .. "\"" .. value .. "\",";
 		end
+	else
+		str = str .. tostring(value) .. ",";
 	end
 	return str;
 end
@@ -310,50 +351,75 @@ app:RegisterDataStyleExporter("raw", {
 	afterExport = function(data) return "} -- End Raw Data" end
 })
 
--- helpers for readable style
 local KnownShortcutsByType = {
 	Currency = "currency",
+	Decor = "i",
+	Exploration = "exploration",
+	FlightPath = "fp",
 	Header = "n",
 	Item = "i",
 	Map = "m",
 	NPC = "n",
 	Objective = "objective",
 	Quest = "q",
+	QuestAsBreadcrumb = "q",
 }
+local KeySwaps
+do
+local function DefaultKeyVal(data) return data[data.key] end
+KeySwaps = setmetatable({
+	Decor = function(data)
+		data.__ExportTEMP.ignore.itemID=1
+		data.__ExportTEMP.ignore.spellID=1
+		return data.itemID
+	end,
+	Header = function(data)
+		local id = data[data.key]
+		for k,i in pairs(app.HeaderConstants) do
+			if i == id then
+				return k
+			end
+		end
+	end,
+}, { __index = function(t,k)
+	return DefaultKeyVal
+end})
+end
 local function FormatReadableKey(data)
-	local hasKey = data and data.key
-	if not hasKey then return end
+	if not data or not data.key then return end
 
-	local id = data[hasKey]
 	local shortcut = KnownShortcutsByType[data.__type]
 	-- unknown key shortcut, fall back to nil so we treat it as unkeyed
 	if not shortcut then return end
 
-	if hasKey == "headerID" then
-		for k,i in pairs(app.HeaderConstants) do
-			if i == id then
-				id = k;
-				break;
-			end
-		end
-	end
-
+	local id = KeySwaps[data.__type](data)
 	return shortcut.."("..(id or UNKNOWN)
 end
 
+local IgnoredForReadable = setmetatable({
+	g = true,
+	name = true,
+	basename = true,
+	text = true,
+}, { __index = CleanFields })
 local function HasUsefulFields(data)
+	if not data then return end
+	if data.__ExportTEMP.useful.fields then return true end
 	for k in pairs(data) do
-		if not CleanFields[k]
-			and k ~= "g"
+		if not IgnoredForReadable[k]
 			and k ~= data.key
+			and not data.__ExportTEMP.ignore[k]
 		then
+			data.__ExportTEMP.useful.fields = true
 			return true
 		end
 	end
 end
 
 local function ReadableBeforeData(data, depth)
-	if not data or data.key == "strKey" then return end
+	if not data then return end
+	data.__ExportTEMP = setmetatable({}, app.MetaTable.AutoTable)
+	if data.key == "strKey" then return end
 	local indent = string.rep("\t", depth)
 	local keyStr = FormatReadableKey(data)
 	local name = data.basename or data.name or data.text
@@ -361,12 +427,14 @@ local function ReadableBeforeData(data, depth)
 	local hasGroups = data.g and #data.g > 0
 	local prefix = indent
 	if keyStr then
+		data.__ExportTEMP.useful.shortcut = 1
 		if anyOther or hasGroups then
 			prefix = prefix .. keyStr .. ", {"
 		else
 			prefix = prefix .. keyStr .. ")"
 		end
 	else
+		data.__ExportTEMP.useful.key = 1
 		prefix = prefix .. "{"
 	end
 	if name then
@@ -379,12 +447,6 @@ local function ReadableBeforeData(data, depth)
 	return prefix
 end
 
-local IgnoredForReadable = setmetatable({
-	g = true,
-	name = true,
-	basename = true,
-	text = true,
-}, { __index = CleanFields })
 local function ReadableMain(data, depth)
 	if data and data.key == "strKey" then return end
 	depth = depth or 0
@@ -393,7 +455,10 @@ local function ReadableMain(data, depth)
 		local datalines = {}
 		local keyindent = "\n" .. indent
 		for key,value in pairs(data) do
-			if not IgnoredForReadable[key] and key ~= data.key then
+			if not IgnoredForReadable[key]
+				and (key ~= data.key or data.__ExportTEMP.useful.key)
+				and not data.__ExportTEMP.ignore[key]
+			then
 				datalines[#datalines + 1] = indent .. ExportKeyValue(key,value):gsub("\n", keyindent)
 			end
 		end
@@ -420,20 +485,23 @@ local function ReadableAfterSub(data, depth)
 end
 
 local function ReadableAfterData(data, depth)
-	if not data or data.key == "strKey" then return end
-	local indent = string.rep("\t", depth)
-	local keyStr = FormatReadableKey(data)
-	local hasGroups = data.g and #data.g > 0
-	if keyStr then
-		if HasUsefulFields(data) or hasGroups then
-			return indent .. "}),"
+	if not data then return end
+	if data.key == "strKey" then
+		data.__ExportTEMP = nil
+		return
+	end
+	local suffix
+	if data.__ExportTEMP.useful.shortcut then
+		if HasUsefulFields(data) or (data.g and #data.g > 0) then
+			suffix = string.rep("\t", depth) .. "}),"
 		else
 			-- simple keyed entry (no other fields, no groups)
-			return
 		end
 	else
-		return indent .. "},"
+		suffix = string.rep("\t", depth) .. "},"
 	end
+	data.__ExportTEMP = nil
+	return suffix
 end
 
 -- register the 'readable' style exporter

--- a/src/UI/Windows/Debugger.lua
+++ b/src/UI/Windows/Debugger.lua
@@ -368,6 +368,7 @@ local KnownShortcutsByType = {
 	Item = "i",
 	Map = "m",
 	NPC = "n",
+	Object = "o",
 	Objective = "objective",
 	Quest = "q",
 	QuestAsBreadcrumb = "q",

--- a/src/UI/Windows/Debugger.lua
+++ b/src/UI/Windows/Debugger.lua
@@ -376,9 +376,16 @@ local function ReadableMain(data, depth)
 	local sub = indent .. "\t"
 	local str = ""
 	for k,v in pairs(data) do
-		if not CleanFields[k] and k ~= "g" and k ~= data.key then
+		-- ignore cleaned fields, groups, the keyed identifier, and name/text fields
+		if not CleanFields[k] and k ~= "g" and k ~= data.key
+			and k ~= "name" and k ~= "basename" and k ~= "text" then
 			str = str .. "\n" .. sub .. ExportKeyValue(k,v):gsub("\n", "\n"..sub)
 		end
+	end
+	-- strip any leading newline (we'll join entries with a newline anyway)
+	str = str:gsub("^\n", "")
+	if str == "" then
+		return nil
 	end
 	return str
 end
@@ -387,10 +394,10 @@ local function ReadableBeforeSub(data, depth)
 	local indent = string.rep("\t", depth)
 	local anyOther = false
 	for k in pairs(data) do
-		if not CleanFields[k] and k ~= "g" then anyOther = true; break end
+		if not CleanFields[k] and k ~= "g" and k ~= data.key then anyOther = true; break end
 	end
 	if not anyOther then
-		-- no non-clean fields (and no keyed value), just let recursion handle children
+		-- only key/ g present, nothing to wrap
 		return
 	end
 	return indent .. "\tgroups = {"
@@ -400,7 +407,7 @@ local function ReadableAfterSub(data, depth)
 	local indent = string.rep("\t", depth)
 	local anyOther = false
 	for k in pairs(data) do
-		if not CleanFields[k] and k ~= "g" then anyOther = true; break end
+		if not CleanFields[k] and k ~= "g" and k ~= data.key then anyOther = true; break end
 	end
 	if not anyOther then return end
 	return indent .. "\t},"

--- a/src/UI/Windows/Import.lua
+++ b/src/UI/Windows/Import.lua
@@ -171,3 +171,21 @@ app:CreateWindow("Import", {
 		self:ResetToInitialButtons()
 	end,
 });
+
+-- register the 'ID' style exporter
+app:RegisterDataStyleExporter("ID", {
+	main = function(data, depth)
+		if data and data.key then
+			return data[data.key] .. ",\t-- " .. (data.name or UNKNOWN)
+		end
+	end
+})
+
+-- register the 'questID' style exporter
+app:RegisterDataStyleExporter("questID", {
+	main = function(data, depth)
+		if data then
+			return (data.questID or "???") .. ",\t-- " .. (data.name or UNKNOWN)
+		end
+	end
+})

--- a/src/base.lua
+++ b/src/base.lua
@@ -793,3 +793,111 @@ app.Modules = {};
 
 -- Global Variables
 AllTheThingsSavedVariables = {};
+
+-- Data style exporters and utility for copying window data via various styles.
+local DataStyleExporters = {};
+
+-- Register a new exporter by name.  If the style already exists or the
+-- provided function is invalid the call is ignored.
+function app:RegisterDataStyleExporter(style, funcs)
+	if type(style) ~= "string" or type(funcs) ~= "table" or type(funcs.main) ~= "function" then
+		app.print("Invalid definition for RegisterDataStyleExporter:", style)
+		return
+	end
+	if DataStyleExporters[style] then
+		app.print("Export Style already defined!",style)
+	end
+	-- Validate optional function keys
+	for key, func in pairs(funcs) do
+		if key ~= "main" and type(func) ~= "function" then
+			app.print("Invalid definition for RegisterDataStyleExporter:", style, "- invalid key:", key)
+			return
+		end
+	end
+	DataStyleExporters[style] = funcs
+end
+
+-- Recursive helper which walks data and its .g subgroups applying the
+-- provided style function and collecting results into the strings array.
+local function ExportDataRecursively(data, styleFuncs, strings, depth)
+	if not data then return end
+	depth = depth or 0
+	local g = data.g
+	if not g or type(g) ~= "table" then
+		g = nil
+	end
+	local str
+	-- run the style exporter and add its result if present
+	if styleFuncs.beforeData then
+		str = styleFuncs.beforeData(data, depth)
+		if str then
+			strings[#strings + 1] = str
+		end
+	end
+	str = styleFuncs.main(data, depth)
+	if str then
+		strings[#strings + 1] = str;
+	end
+	if g then
+		if styleFuncs.beforeSub then
+			str = styleFuncs.beforeSub(data, depth)
+			if str then
+				strings[#strings + 1] = str
+			end
+		end
+		for i=1,#g do
+			ExportDataRecursively(g[i], styleFuncs, strings, depth + 1)
+		end
+		if styleFuncs.afterSub then
+			str = styleFuncs.afterSub(data, depth)
+			if str then
+				strings[#strings + 1] = str;
+			end
+		end
+	end
+	if styleFuncs.afterData then
+		str = styleFuncs.afterData(data, depth)
+		if str then
+			strings[#strings + 1] = str
+		end
+	end
+end
+
+-- Accepts a window (string identifier or table) and an export style key.
+-- The style key is looked up in DataStyleExporters; if missing an error message is
+-- shown.  Data from the window and all nested groups is passed through the
+-- exporter and the resulting strings concatenated and displayed in a multi-
+-- line popup for easy copying.
+function app:ExportStylizedData(window, style)
+	-- style must exist and window must have data
+	local styleFuncs = DataStyleExporters[style]
+	if not styleFuncs then
+		app.print("Export Style not defined!",style)
+		return
+	end
+	-- resolve window string to actual window table if needed
+	if type(window) == "string" then
+		window = app:GetWindow(window)
+	end
+	if not window or not window.data then
+		app.print("Export Window not defined or has no data!")
+		return
+	end
+	local DataStyleStrings = {}
+	if styleFuncs.beforeExport then
+		local str = styleFuncs.beforeExport(window.data)
+		if str then
+			DataStyleStrings[#DataStyleStrings + 1] = str
+		end
+	end
+	ExportDataRecursively(window.data, styleFuncs, DataStyleStrings)
+	if styleFuncs.afterExport then
+		local str = styleFuncs.afterExport(window.data)
+		if str then
+			DataStyleStrings[#DataStyleStrings + 1] = str
+		end
+	end
+	-- join each style string with a newline for readability
+	local out = app.TableConcat(DataStyleStrings, nil, nil, "\n")
+	app:ShowPopupDialogWithMultiLineEditBox(out)
+end

--- a/src/base.lua
+++ b/src/base.lua
@@ -845,8 +845,9 @@ local function ExportDataRecursively(data, styleFuncs, strings, depth)
 				strings[#strings + 1] = str
 			end
 		end
+		local depthShift = styleFuncs.depthShift and styleFuncs.depthShift(data) or 1
 		for i=1,#g do
-			ExportDataRecursively(g[i], styleFuncs, strings, depth + 1)
+			ExportDataRecursively(g[i], styleFuncs, strings, depth + depthShift)
 		end
 		if styleFuncs.afterSub then
 			str = styleFuncs.afterSub(data, depth)


### PR DESCRIPTION
Instead of export tech being specific to the Debugger window, I would like it to be a reusable public API and allow alternate styles to be configured for custom use.
Currently, the 'raw' and 'readable' exporters from Debugger are now available for use. I plan to add other base styles for export and have further adjustments to make so that DLO groups are handled properly when exporting.