### PR TITLE
Fix coords format in World Quests to prevent "attempt to index local 'coord' (a number value)" error

### DIFF
--- a/src/UI/Windows/World Quests.lua
+++ b/src/UI/Windows/World Quests.lua
@@ -201,7 +201,7 @@ app:CreateWindow("WorldQuests", {
 								-- end
 								-- add the map POI coords to our new quest object
 								if poi.x and poi.y then
-									questObject.coords = { [mapID] = { 100 * poi.x, 100 * poi.y }}
+									questObject.coords = { [mapID] = { { 100 * poi.x, 100 * poi.y } }}
 								end
 								NestObject(mapObject, questObject);
 								-- see if need to retry based on missing data
@@ -258,7 +258,7 @@ app:CreateWindow("WorldQuests", {
 							x, y = nil, nil
 						end
 						if x and y then
-							o.coords = { [mapID] = { 100 * x, 100 * y }}
+							o.coords = { [mapID] = { { 100 * x, 100 * y } }}
 						end
 						if not poiMapID or poiMapID == mapID or poi.isPrimaryMapForPOI then
 							NestObject(mapObject, o)


### PR DESCRIPTION
## Problem
Tooltips crash with "attempt to index local 'coord' (a number value)" at Interface - Information.lua:701 when hovering over objects whose coords come from World Quests/Area POIs (e.g. encounterID 2199, questID 52163 on map 895).

See Discord message with report here: [https://discord.com/channels/242423099184775169/1278179718637813810/1481672093035663462](url)

## Root Cause
World Quests.lua was storing coords as a flat pair `{ x, y }`, while all consumers (Interface - Information, Tooltip, Contributor, Waypoints, Maps) expect `{ { x, y } }` (array of coordinate pairs). During iteration, `coord` was a number, so `coord[1]` and `coord[2]` caused the error.

## Fix
Update both coords assignments in World Quests.lua to use the correct format:
- Line 204: Quest POI coords
- Line 261: Area POI coords

Change `{ [mapID] = { x, y } }` to `{ [mapID] = { { x, y } } }` to match the format used elsewhere (e.g. Debugger.lua, database coords).


Full error stack if needed:
```Lua
6x ...hings/src/Settings/Pages/Interface - Information.lua:701: attempt to index local 'coord' (a number value)
[AllTheThings/src/Settings/Pages/Interface - Information.lua]:701: in function 'Process'
[AllTheThings/src/Settings/Pages/Interface - Information.lua]:1402: in function 'ProcessInformationTypes'
[AllTheThings/src/UI/Window Definitions.lua]:1320: in function <...ceAllTheThings/src/UI/Window Definitions.lua:1201>


Locals:
t = <table> {
 textLower = "coordinates"
 ShouldDisplayInExternalTooltips = false
 priority = 2.100000
 text = "Coordinates"
 maxcoords = 10
 informationTypeID = "coords"
}
reference = <table> {
 sourceParent = <table> {
 }
 isWeekly = 1
 nmr = false
 progress = 1
 coords = <table> {
 }
 g = <table> {
 }
 encounterID = 2199
 _cata = 0
 isRaid = 1
 hash = "encounterID2199:136385"
 total = 3
 maps = <table> {
 }
 parent = <table> {
 }
 __FillGroups = true
 questID = 52163
 visible = true
 npcID = 136385
 nmc = false
 upgradeTotal = 0
 TLUG = 308118.481177
 costTotal = 0
 __canretry = false
 __merge = <table> {
 }
 HasRetried = true
}
tooltipInfo = <table> {
 1 = <table> {
 }
 2 = <table> {
 }
 3 = <table> {
 }
}
coords = <table> {
 895 = <table> {
 }
}
coordList = <table> {
}
currentMapID = 895
(for state) = <table> {
 1 = 62.652433
 2 = 23.178756
}
(for control) = 1
i = 1
coord = 62.652433
(*temporary) = <table> {
}
(*temporary) = <table> {
}
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = "attempt to index local 'coord' (a number value)"
app = <table> {
 ExplorationAreaPositionDB = <table> {
 }
 OnTooltipDB = <table> {
 }
 FunctionRunner = <table> {
 }
 WindowDefinitions = <table> {
 }
 ExplorationAreaPositionDB_SavedVars = <table> {
 }
 ChatCommands = <table> {
 }
 OnUpdateDB = <table> {
 }
 NonOPAQDB = <table> {
 }
 HeaderData = <table> {
 }
 SortDefaults = <table> {
 }
 GameBuildVersion = 120001
 events = <table> {
 }
 Runners = <table> {
 }
 ClassIndex = 2
 UniqueCounter = <table> {
 }
 Presets = <table> {
 }
 Colors = <table> {
 }
 MapRemapping = <table> {
 }
 CurrentCharacter = <table> {
 }
 TW_EventIDs = <table> {
 }
 L = <table> {
 }
 PhaseConstants = <table> {
 }
 ItemConversionDB = <table> {
 }
 ActiveRowReference = <table> {
 }
 ObjectModels = <table> {
 }
 ClassInfoByID = <table> {
 }
 TradeskillTab = Frame {
 }
 CreatedTabAuction = true
 AuctionHouseTab = Frame {
 }
 MaxSourceID = 305119
 CurrentMapID = 895
 IsReady = true
 _SettingsRefresh = 307225.656703
 CallbackHandlers = <table> {
 }
 NPCDisplayIDFromID = <table> {
 }
 ObjectNames = <table> {
 }
 Audio = <table> {
 }
 HeaderConstants = <table> {
 }
 ClassName = "|cfff48cbaPaladin|r"
 Modules = <table> {
 }
 CreatedTabTradeskill = true
 Windows = <table> {
 }
 IsRetail = true
 AfterCata = true
 Race = "Dwarf"
 Search = <table> {
 }
 UI = <table> {
 }
 EmptyTable = <table> {
 }
 RaceIndex = 3
 QuestLockCriteriaFunctions = <table> {
 }
 FillRunner = <table> {
 }
 PlayerProgressCacheByGUID = <table> {
 }
 ReagentsDB = <table> {
 }
 NPCNameFromID = <table> {
 }
 Version = "5.0.17-70-g3b16dc9"
 ClassInfoByClassName = <table> {
 }
 SpellNameToSpellID = <table> {
 }
 SkillDB = <table> {
 }
 ThingKeys = <table> {
 }
 UpdateRunner = <table> {
 }
 ClassInfoByClassFile = <table> {
 }
 Level = 90
 GlobalVariants = <table> {
 }
 NPCTitlesFromID = <table> {
 }
 WOWAPI = <table> {
 }
 DefaultColors = <table> {
 }
 RaceID = 3
 BaseClass = <table> {
 }
 RealMapID = 895
 ActiveVignettes = <table> {
 }
 frame = Frame {
 }
 GUID = "Player-60-0EF38781"
 DESCRIPTION_SEPARATOR = "`"
 OPAQDB = <table> {
 }
 Class = "PALADIN"
 MetaTable = <table> {
 }
 Settings = AllTheThings-Settings {
 }
 AccountUniqueSources = <table> {
 }
 AccountWideQuestsDB = <table> {
 }
 Gender = 2
 FlightPathDB = <table> {
 }
 FilterConstants = <table> {
 }
 FactionID = 2
 ArtifactDB = <table> {
 }
 IsClassic = false
 Faction = "Alliance"
 SourceSearcher = <table> {
 }
 ObjectIcons = <table> {
 }
 GlyphDB = <table> {
 }
 ForceFillDB = <table> {
 }
 CategoryIcons = <table> {
 }
 RaceDB = <table> {
 }
 ActiveCustomCollects = <table> {
 }
 Me = "|cfff48cbaDack-Stormrage|r"
 CurrentMapInfo = <table> {
 }
}
L = <table> {
 NOT_TRADEABLE = "Not Tradeable"
 FILL_NPC_DATA_CHECKBOX_TOOLTIP = "Enable this option if you want to fill all relevant data for a given NPC (Common Boss Drops, Drops, etc). This option may cause a significant amount 
```