### PR TITLE
[Logic] Fix tooltip taint crash in RowOnEnter

### DIFF
--- a/src/UI/Window Definitions.lua
+++ b/src/UI/Window Definitions.lua
@@ -1712,7 +1712,9 @@ local function RowOnEnter(self)
 	-- Attach all of the Information to the tooltip.
 	app.Modules.Tooltip.AttachTooltipInformation(tooltip, tooltipInfo);
 	if not IsRefreshing then tooltip:SetATTReferenceForTexture(reference); end
-	tooltip:Show();
+	-- Defer Show() to the next frame to break the addon taint chain.
+	-- Without this, Backdrop.lua tries arithmetic on secret-tainted width/height values.
+	C_Timer.After(0, function() tooltip:Show(); end);
 
 	-- Reactivate the original tooltip integrations setting.
 	if wereTooltipIntegrationsDisabled then app.Settings:SetTooltipSetting("Enabled", false); end


### PR DESCRIPTION
## Summary

`tooltip:Show()` in `RowOnEnter` runs with AllTheThings addon taint. This causes `Backdrop.lua:226` to crash:

```
attempt to perform arithmetic on local 'width' (a secret number value tainted by 'AllTheThings')
```

`GetWidth()`/`GetHeight()` return secret values when called in a tainted execution context, so Backdrop.lua can't do math on them.

## Fix

Wrap the `tooltip:Show()` call in `C_Timer.After(0, ...)` to defer it to the next frame. This starts a clean execution stack with no addon taint. The tooltip content is already fully attached before `Show()` is called, so the one-frame delay is safe — the tooltip just becomes visible one frame later.

## Test plan

- Hover over any row in an ATT window
- Confirm tooltip appears normally (with a negligible one-frame delay)
- Confirm no Backdrop.lua taint errors in BugGrabber/BugSack