### PR TITLE
Update cost of Vrykul Lord’s Throne to 12000

### DIFF
--- a/.contrib/Parser/DATAS/02 - Outdoor Zones/08 Broken Isles/1 - Dalaran/The Underbelly.lua
+++ b/.contrib/Parser/DATAS/02 - Outdoor Zones/08 Broken Isles/1 - Dalaran/The Underbelly.lua
@@ -380,7 +380,7 @@ root(ROOTS.Zones, {
 								}),
 								i(250402, {	-- Vrykul Lord’s Throne (DECOR!)
 									["cost"] = {
-										{ "c", ORDER_RESOURCES, 18000 },
+										{ "c", ORDER_RESOURCES, 12000 },
 										{ "c", VEILED_ARGUNITE,    50 },
 									},
 								}),


### PR DESCRIPTION
18k to 12k about 

https://www.wowhead.com/fr/item=250402/tr%C3%B4ne-de-seigneur-vrykul

![WoWScrnShot_041026_174724](https://github.com/user-attachments/assets/239f9d1c-8bd9-4dad-8f59-4e382ba0f5b3)
