### PR TITLE
[Classic] fix TBC anniversary heroic pack rewards for MOP

### DIFF
--- a/.contrib/Parser/DATAS/12 - Promotions/Collector's Editions.lua
+++ b/.contrib/Parser/DATAS/12 - Promotions/Collector's Editions.lua
@@ -708,11 +708,19 @@ root(ROOTS.Promotions, n(COLLECTORS_EDITION, bubbleDownSelf({ ["u"] = REAL_MONEY
 	n(TBC_CLASSIC_ANNIVERSARY_OUTLAND_UPGRADE, bubbleDownSelf({ ["timeline"] = { ADDED_5_5_2, REMOVED_6_0_2, ADDED_11_2_5 } }, {
 		["description"] = "These rewards were made available to anyone who purchased the Outland Heroic Pack of The Burning Crusade Classic Anniversary.",
 		["groups"] = {
+			-- #if AFTER 11.2.5
 			i(253573),	-- Cobalt Phase-Hunter (MOUNT!)
 			i(254666),	-- Exodar Replica (TOY!)
 			i(263489),	-- Naaru's Enfold (TOY!)
 			i(253699),	-- Starshard Whelpling (PET!)
 			i(252950),	-- Starspark Netherdrake (MOUNT!)
+			-- #else
+			i(260438),	-- Cerulean Phase-Hunter (MOUNT!)
+			i(260622),	-- Exodar Replica (TOY!)
+			i(260221),	-- Naaru's Embrace (TOY!)
+			i(260759),	-- Reins of the Starshard Netherdrake (MOUNT!)
+			i(260433),	-- Starshard Whelpling (PET!)
+			-- #endif
 		},
 	})),
 	-- #endif


### PR DESCRIPTION
on MOP, rewards ids are the same as in BC