### PR TITLE
[Classic] Add Midsummer event new 528 items in MOP

### DIFF
--- a/.contrib/Parser/.config/classic/05 - Mists of Pandaria.config
+++ b/.contrib/Parser/.config/classic/05 - Mists of Pandaria.config
@@ -5,7 +5,7 @@
 	"json-directories": [ ],
     "db-relative": "Mists/",
     "DataPhase": "MOP",
-    "DataPatch": [ 5, 5, 3, 64857 ],
+    "DataPatch": [ 5, 5, 4, 68159 ],
     "PreProcessorTags": [
         "ANYCLASSIC",
 		"MOP",

--- a/.contrib/Parser/.config/classic/05 - Mists of Pandaria.config
+++ b/.contrib/Parser/.config/classic/05 - Mists of Pandaria.config
@@ -5,7 +5,7 @@
 	"json-directories": [ ],
     "db-relative": "Mists/",
     "DataPhase": "MOP",
-    "DataPatch": [ 5, 5, 4, 68159 ],
+    "DataPatch": [ 5, 5, 4, 68317 ],
     "PreProcessorTags": [
         "ANYCLASSIC",
 		"MOP",

--- a/.contrib/Parser/DATAS/21 - Holidays/Midsummer Fire Festival.lua
+++ b/.contrib/Parser/DATAS/21 - Holidays/Midsummer Fire Festival.lua
@@ -510,9 +510,16 @@ root(ROOTS.Holidays, applyevent(EVENTS.MIDSUMMER_FIRE_FESTIVAL, n(MIDSUMMER_FIRE
 			i(54536, {	-- Satchel of Chilled Goods
 				["timeline"] = { ADDED_3_3_3, REMOVED_6_0_2 },
 				["groups"] = {
+					-- NOTE: Blizzard added 528 ilvl items specific to MOP_PHASE_ONE Classic
+					-- #if ANYCLASSIC
+					i(280389, {	-- Frostscythe of Lord Ahune [Level 90]
+						["timeline"] = { ADDED_5_5_4, REMOVED_6_0_2 },
+					}),
+					-- #else
 					i(95426, {	-- Frostscythe of Lord Ahune [Level 90]
 						["timeline"] = { ADDED_5_0_4, REMOVED_6_0_2 },
 					}),
+					-- #endif
 
 					-- WOUTER NOTE: Blizzard added 403 ilvl items specific to Cata Classic, probably because Midsummer happened a 2nd time in late Dragon Soul
 					-- #if ANYCLASSIC
@@ -571,6 +578,24 @@ root(ROOTS.Holidays, applyevent(EVENTS.MIDSUMMER_FIRE_FESTIVAL, n(MIDSUMMER_FIRE
 				["timeline"] = { ADDED_6_0_2 },
 			}),
 
+			-- NOTE: Blizzard added 528 ilvl items specific to MOP Classic
+			-- #if ANYCLASSIC
+			i(280386, {	-- Cloak of the Frigid Winds [528]
+				["timeline"] = { ADDED_5_5_4, REMOVED_6_0_2 },
+			}),
+			i(280383, {	-- Icebound Cloak [Level 90]
+				["timeline"] = { ADDED_5_5_4, REMOVED_6_0_2 },
+			}),
+			i(280385, {	-- Shroud of Winter's Chill [Level 90]
+				["timeline"] = { ADDED_5_5_4, REMOVED_6_0_2 },
+			}),
+			i(280384, {	-- The Frost Lord's Battle Shroud [Level 90]
+				["timeline"] = { ADDED_5_5_4, REMOVED_6_0_2 },
+			}),
+			i(280387, {	-- The Frost Lord's War Cloak [Level 90]
+				["timeline"] = { ADDED_5_5_4, REMOVED_6_0_2 },
+			}),
+			-- #else
 			-- Pandaria Rewards
 			i(95425, {	-- Cloak of the Frigid Winds [Level 90]
 				["timeline"] = { ADDED_5_0_4, REMOVED_6_0_2 },
@@ -587,6 +612,7 @@ root(ROOTS.Holidays, applyevent(EVENTS.MIDSUMMER_FIRE_FESTIVAL, n(MIDSUMMER_FIRE
 			i(95430, {	-- The Frost Lord's War Cloak [Level 90]
 				["timeline"] = { ADDED_5_0_4, REMOVED_6_0_2 },
 			}),
+			-- #endif
 
 			-- WOUTER NOTE: Blizzard added 403 ilvl items specific to Cata Classic, probably because Midsummer happened a 2nd time in late Dragon Soul
 			-- #if ANYCLASSIC


### PR DESCRIPTION
https://www.wowhead.com/mop-classic/guide/holidays/midsummer-fire-festival-guide#ahune-loot